### PR TITLE
Fix new character creation flow

### DIFF
--- a/public/player_client.js
+++ b/public/player_client.js
@@ -36,9 +36,8 @@ window.onload = function () {
       currentChar = { name: text };
       socket.emit('saveCharacter', currentChar);
       printMessage(`Created new character ${text}.`);
-      localStorage.setItem('characterName', currentChar.name);
-      phase = 'playing';
-      } else if (phase === 'playing') {
+      phase = 'loading';
+    } else if (phase === 'playing') {
         printMessage('> ' + text);
         socket.emit('playerMessage', { name: currentChar.name, message: text });
       }

--- a/server.js
+++ b/server.js
@@ -69,6 +69,7 @@ io.on("connection", (socket) => {
     fs.writeFile(CHAR_FILE, JSON.stringify(savedCharacters, null, 2), (err) => {
       if (err) console.error("Save error:", err);
     });
+    socket.emit("characterLoaded", charData);
   });
 
   socket.on("deleteCharacter", (name) => {


### PR DESCRIPTION
## Summary
- emit a `characterLoaded` event from the server when a character is saved
- wait for the server response before entering the playing phase

## Testing
- `node --check server.js`
- `node --check public/player_client.js`


------
https://chatgpt.com/codex/tasks/task_e_685aa2e44fa0833299c1ccb39bce72a5