### PR TITLE
Add mobile pages for character menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,10 @@
 <html>
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>OSE RPG Entry</title>
   <style>
-    body { background: black; color: lime; font-family: monospace; padding: 2rem; }
+    body { background: black; color: lime; font-family: monospace; padding: 2rem; max-width: 600px; margin: 0 auto; font-size: 18px; line-height: 1.4; }
     a { color: #00ffcc; display: block; margin: 1rem 0; }
   </style>
 </head>

--- a/public/character.html
+++ b/public/character.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Character Sheet</title>
+  <style>
+    body {
+      background: black;
+      color: lime;
+      font-family: monospace;
+      padding: 1rem;
+      margin: 0 auto;
+      max-width: 600px;
+      font-size: 18px;
+      line-height: 1.4;
+    }
+    a { color: #00ffcc; }
+  </style>
+</head>
+<body>
+  <pre id="charDisplay">Loading...</pre>
+  <p><a href="player.html">&#x2B05; Back</a></p>
+
+  <script src="/socket.io/socket.io.js"></script>
+  <script>
+    const display = document.getElementById('charDisplay');
+    const socket = io();
+    const name = localStorage.getItem('characterName');
+    if (name) {
+      socket.emit('loadCharacter', name);
+    } else {
+      display.textContent = 'No character found.';
+    }
+    socket.on('characterLoaded', (charData) => {
+      const s = charData.stats || {};
+      display.textContent =
+        charData.name + '\n' +
+        'Class: ' + charData.class + ' ' + charData.alignment + '\n' +
+        `STR:${s.STR} DEX:${s.DEX} CON:${s.CON} INT:${s.INT} WIS:${s.WIS} CHA:${s.CHA}\n` +
+        `HP:${charData.hp} AC:${charData.ac} XP:${charData.xp}/${charData.nextLevelXP}`;
+    });
+  </script>
+</body>
+</html>

--- a/public/chat.html
+++ b/public/chat.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Chat</title>
+  <style>
+    body {
+      background: black;
+      color: lime;
+      font-family: monospace;
+      padding: 1rem;
+      margin: 0 auto;
+      max-width: 600px;
+      font-size: 18px;
+      line-height: 1.4;
+    }
+    a { color: #00ffcc; }
+    pre { height: 60vh; overflow-y: auto; white-space: pre-wrap; border: 1px solid #0f0; padding: 0.5rem; }
+    input { width: 100%; font-size: 18px; margin-top: 0.5rem; }
+  </style>
+</head>
+<body>
+  <pre id="log"></pre>
+  <input id="chatInput" placeholder="message" autocomplete="off" />
+  <p><a href="player.html">&#x2B05; Back</a></p>
+
+  <script src="/socket.io/socket.io.js"></script>
+  <script>
+    const socket = io();
+    const logEl = document.getElementById('log');
+    const input = document.getElementById('chatInput');
+    const name = localStorage.getItem('characterName') || 'Anon';
+
+    socket.emit('getCampaignLog');
+    socket.on('campaignLog', (log) => {
+      logEl.textContent = log.join('\n');
+    });
+    socket.on('logUpdate', (entry) => {
+      logEl.textContent += '\n' + entry;
+      logEl.scrollTop = logEl.scrollHeight;
+    });
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' && input.value.trim()) {
+        socket.emit('playerMessage', { name, message: input.value.trim() });
+        input.value = '';
+      }
+    });
+  </script>
+</body>
+</html>

--- a/public/dm.html
+++ b/public/dm.html
@@ -2,12 +2,18 @@
 <html>
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>OSE RPG - GM Tools</title>
   <style>
     body {
       background: black;
       color: lime;
       font-family: monospace;
+      margin: 0 auto;
+      max-width: 600px;
+      padding: 1rem;
+      font-size: 18px;
+      line-height: 1.4;
     }
     canvas {
       border: 1px solid lime;

--- a/public/index.html
+++ b/public/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>OSE RPG Entry</title>
   <style>
     body {
@@ -9,6 +10,10 @@
       color: lime;
       font-family: monospace;
       padding: 2rem;
+      max-width: 600px;
+      margin: 0 auto;
+      font-size: 18px;
+      line-height: 1.4;
     }
     a { color: #00ffcc; display: block; margin: 1rem 0; }
   </style>

--- a/public/items.html
+++ b/public/items.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Items</title>
+  <style>
+    body {
+      background: black;
+      color: lime;
+      font-family: monospace;
+      padding: 1rem;
+      margin: 0 auto;
+      max-width: 600px;
+      font-size: 18px;
+      line-height: 1.4;
+    }
+    a { color: #00ffcc; }
+  </style>
+</head>
+<body>
+  <pre id="itemsDisplay">Loading...</pre>
+  <p><a href="player.html">&#x2B05; Back</a></p>
+
+  <script src="/socket.io/socket.io.js"></script>
+  <script>
+    const display = document.getElementById('itemsDisplay');
+    const socket = io();
+    const name = localStorage.getItem('characterName');
+    if (name) {
+      socket.emit('loadCharacter', name);
+    } else {
+      display.textContent = 'No character found.';
+    }
+    socket.on('characterLoaded', (charData) => {
+      display.textContent = 'Items:\n' + (charData.inventory || []).join('\n');
+    });
+  </script>
+</body>
+</html>

--- a/public/journal.html
+++ b/public/journal.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Journal</title>
+  <style>
+    body {
+      background: black;
+      color: lime;
+      font-family: monospace;
+      padding: 1rem;
+      margin: 0 auto;
+      max-width: 600px;
+      font-size: 18px;
+      line-height: 1.4;
+    }
+    a { color: #00ffcc; }
+    pre { white-space: pre-wrap; }
+  </style>
+</head>
+<body>
+  <pre id="journal">Loading...</pre>
+  <p><a href="player.html">&#x2B05; Back</a></p>
+
+  <script src="/socket.io/socket.io.js"></script>
+  <script>
+    const display = document.getElementById('journal');
+    const socket = io();
+    socket.emit('getCampaignLog');
+    socket.on('campaignLog', (log) => {
+      display.textContent = log.join('\n');
+    });
+    socket.on('logUpdate', (entry) => {
+      display.textContent += '\n' + entry;
+    });
+  </script>
+</body>
+</html>

--- a/public/map.html
+++ b/public/map.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Map</title>
+  <style>
+    body {
+      background: black;
+      color: lime;
+      font-family: monospace;
+      padding: 1rem;
+      margin: 0 auto;
+      max-width: 600px;
+      font-size: 18px;
+      line-height: 1.4;
+    }
+    a { color: #00ffcc; }
+    pre { white-space: pre-wrap; }
+  </style>
+</head>
+<body>
+  <pre id="mapDisplay">Loading...</pre>
+  <p><a href="player.html">&#x2B05; Back</a></p>
+
+  <script src="/socket.io/socket.io.js"></script>
+  <script>
+    const display = document.getElementById('mapDisplay');
+    const socket = io();
+    socket.emit('getMap');
+    socket.on('mapData', (data) => {
+      display.textContent = data.map(row => row.join('')).join('\n');
+    });
+  </script>
+</body>
+</html>

--- a/public/player.html
+++ b/public/player.html
@@ -2,21 +2,25 @@
 <html>
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>OSE RPG - Player</title>
   <style>
     body {
       background: black;
       color: lime;
       font-family: monospace;
-      margin: 0;
+      margin: 0 auto;
       padding: 1rem;
+      max-width: 600px;
+      font-size: 18px;
+      line-height: 1.4;
     }
     #gameDisplay {
       width: 100%;
       height: 70vh;
       background: #000;
       color: #0f0;
-      font-size: 16px;
+      font-size: 18px;
       border: 1px solid #0f0;
       padding: 1rem;
       white-space: pre-wrap;
@@ -24,7 +28,7 @@
     }
     #commandInput {
       width: 100%;
-      font-size: 16px;
+      font-size: 18px;
       padding: 0.5rem;
       border: 1px solid #0f0;
       background: black;

--- a/public/player_client.js
+++ b/public/player_client.js
@@ -44,7 +44,8 @@ window.onload = function () {
         '2. Items\n' +
         '3. Map\n' +
         '4. Chat\n' +
-        '5. Journal'
+        '5. Journal\n' +
+        '(Selecting an option opens a new page)'
     );
     phase = 'menu';
   }
@@ -176,22 +177,19 @@ window.onload = function () {
     } else if (phase === 'menu') {
       switch (text) {
         case '1':
-          showCharacterSheet();
+          window.location.href = 'character.html';
           break;
         case '2':
-          showItems();
+          window.location.href = 'items.html';
           break;
         case '3':
-          socket.emit('getMap');
-          phase = 'map';
+          window.location.href = 'map.html';
           break;
         case '4':
-          printMessage('Enter message, 0 to return');
-          phase = 'chat';
+          window.location.href = 'chat.html';
           break;
         case '5':
-          socket.emit('getCampaignLog');
-          phase = 'journal';
+          window.location.href = 'journal.html';
           break;
         default:
           printMessage('Invalid choice.');


### PR DESCRIPTION
## Summary
- create separate pages for character sheet, items, map, chat and journal
- link menu options to these new pages
- add Back links on each page
- improve mobile readability of all HTML pages

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685aac88ebb48332a501674add83ab6d