### PR TITLE
Add token handling and colorized log entries

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -17,6 +17,12 @@
     }
     a { color: #00ffcc; }
     pre { height: 60vh; overflow-y: auto; white-space: pre-wrap; border: 1px solid #0f0; padding: 0.5rem; }
+    .char { color: deepskyblue; }
+    .location { color: violet; }
+    .item { color: gold; }
+    .spell { color: orchid; }
+    .monster { color: tomato; }
+    .gold { color: khaki; }
     input { width: 100%; font-size: 18px; margin-top: 0.5rem; }
   </style>
 </head>
@@ -32,12 +38,22 @@
     const input = document.getElementById('chatInput');
     const name = localStorage.getItem('characterName') || 'Anon';
 
+    function colorize(text) {
+      return text
+        .replace(/#([\w ]+)/g, '<span class="item">#$1</span>')
+        .replace(/\$(\d+)/g, '<span class="gold">$$$1</span>')
+        .replace(/@([\w ]+)/g, '<span class="char">@$1</span>')
+        .replace(/&([\w ]+)/g, '<span class="location">&$1</span>')
+        .replace(/!([\w ]+)/g, '<span class="spell">!$1</span>')
+        .replace(/%([\w ]+)/g, '<span class="monster">%$1</span>');
+    }
+
     socket.emit('getCampaignLog');
     socket.on('campaignLog', (log) => {
-      logEl.textContent = log.join('\n');
+      logEl.innerHTML = log.map(colorize).join('<br>');
     });
     socket.on('logUpdate', (entry) => {
-      logEl.textContent += '\n' + entry;
+      logEl.innerHTML += '<br>' + colorize(entry);
       logEl.scrollTop = logEl.scrollHeight;
     });
     input.addEventListener('keydown', (e) => {

--- a/public/dm.html
+++ b/public/dm.html
@@ -18,6 +18,12 @@
     canvas {
       border: 1px solid lime;
     }
+    .char { color: deepskyblue; }
+    .location { color: violet; }
+    .item { color: gold; }
+    .spell { color: orchid; }
+    .monster { color: tomato; }
+    .gold { color: khaki; }
   </style>
 </head>
 <body>

--- a/public/gm_menu.js
+++ b/public/gm_menu.js
@@ -8,6 +8,16 @@ const cellSize = 30;
 let mode = 'menu';
 let mapData = [];
 
+function colorize(text) {
+  return text
+    .replace(/#([\w ]+)/g, '<span class="item">#$1</span>')
+    .replace(/\$(\d+)/g, '<span class="gold">$$$1</span>')
+    .replace(/@([\w ]+)/g, '<span class="char">@$1</span>')
+    .replace(/&([\w ]+)/g, '<span class="location">&$1</span>')
+    .replace(/!([\w ]+)/g, '<span class="spell">!$1</span>')
+    .replace(/%([\w ]+)/g, '<span class="monster">%$1</span>');
+}
+
 function showMenu() {
   display.textContent =
     'GM Menu\n' +
@@ -90,11 +100,11 @@ socket.on('allCharacters', (chars) => {
 });
 
 socket.on('campaignLog', (log) => {
-  logDisplay.textContent = log.join('\n');
+  logDisplay.innerHTML = log.map(colorize).join('<br>');
 });
 
 socket.on('logUpdate', (entry) => {
-  logDisplay.textContent += entry + '\n';
+  logDisplay.innerHTML += '<br>' + colorize(entry);
 });
 
 socket.on('mapData', (data) => {

--- a/public/journal.html
+++ b/public/journal.html
@@ -17,6 +17,12 @@
     }
     a { color: #00ffcc; }
     pre { white-space: pre-wrap; }
+    .char { color: deepskyblue; }
+    .location { color: violet; }
+    .item { color: gold; }
+    .spell { color: orchid; }
+    .monster { color: tomato; }
+    .gold { color: khaki; }
   </style>
 </head>
 <body>
@@ -27,12 +33,21 @@
   <script>
     const display = document.getElementById('journal');
     const socket = io();
+    function colorize(text) {
+      return text
+        .replace(/#([\w ]+)/g, '<span class="item">#$1</span>')
+        .replace(/\$(\d+)/g, '<span class="gold">$$$1</span>')
+        .replace(/@([\w ]+)/g, '<span class="char">@$1</span>')
+        .replace(/&([\w ]+)/g, '<span class="location">&$1</span>')
+        .replace(/!([\w ]+)/g, '<span class="spell">!$1</span>')
+        .replace(/%([\w ]+)/g, '<span class="monster">%$1</span>');
+    }
     socket.emit('getCampaignLog');
     socket.on('campaignLog', (log) => {
-      display.textContent = log.join('\n');
+      display.innerHTML = log.map(colorize).join('<br>');
     });
     socket.on('logUpdate', (entry) => {
-      display.textContent += '\n' + entry;
+      display.innerHTML += '<br>' + colorize(entry);
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- parse `#item` and `$amount` in chat messages to consume items and deduct gold
- highlight game elements in `chat.html`, GM screen, and journal
- color styling for characters, locations, items, spells, monsters, and gold

## Testing
- `node --check server.js`
- `node --check public/gm_menu.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ab01d8b5c8332b805087c209134c7