### PR TITLE
Add customizable name style

### DIFF
--- a/public/character.html
+++ b/public/character.html
@@ -58,9 +58,15 @@
     let currentChar = null;
     socket.on('characterLoaded', (charData) => {
       currentChar = charData;
+      if (!currentChar.nameColor) currentChar.nameColor = '#00bfff';
+      if (!currentChar.nameFont) currentChar.nameFont = 'monospace';
       const s = charData.stats || {};
+      const fonts = ['monospace','serif','sans-serif','cursive','fantasy'];
+      const fontOptions = fonts.map(f =>
+        `<option value="${f}"${currentChar.nameFont===f?' selected':''}>${f}</option>`
+      ).join('');
       display.innerHTML =
-        `<strong>${charData.name}</strong><br>` +
+        `<strong id="previewName" style="color:${currentChar.nameColor}; font-family:${currentChar.nameFont}">${charData.name}</strong><br>` +
         `Class: ${charData.class} ${charData.alignment}<br>` +
         `Career: ${charData.career || ''}<br>` +
         `STR:${s.STR} DEX:${s.DEX} CON:${s.CON} INT:${s.INT} WIS:${s.WIS} CHA:${s.CHA}<br>` +
@@ -71,11 +77,24 @@
           const enc = encumbrance(charData);
           return `ENC:${enc.slots} MV:${enc.mv}<br>`;
         })() +
+        `Name Color: <input id="colorInput" type="color" value="${currentChar.nameColor}"><br>` +
+        `Name Font: <select id="fontSelect">${fontOptions}</select><br>` +
         `<button id="saveBtn">Save</button>`;
+
+      const colorInput = document.getElementById('colorInput');
+      const fontSelect = document.getElementById('fontSelect');
+      colorInput.oninput = () => {
+        document.getElementById('previewName').style.color = colorInput.value;
+      };
+      fontSelect.onchange = () => {
+        document.getElementById('previewName').style.fontFamily = fontSelect.value;
+      };
 
       document.getElementById('saveBtn').onclick = () => {
         currentChar.hp = parseInt(document.getElementById('hpInput').value, 10);
         currentChar.xp = parseInt(document.getElementById('xpInput').value, 10);
+        currentChar.nameColor = colorInput.value;
+        currentChar.nameFont = fontSelect.value;
         socket.emit('saveCharacter', currentChar);
         alert('Character saved');
       };

--- a/public/chat.html
+++ b/public/chat.html
@@ -37,15 +37,33 @@
     const logEl = document.getElementById('log');
     const input = document.getElementById('chatInput');
     const name = localStorage.getItem('characterName') || 'Anon';
+    let charStyles = {};
+
+    socket.emit('loadAllCharacters');
+    socket.on('allCharacters', (chars) => {
+      charStyles = {};
+      for (const [n, data] of Object.entries(chars)) {
+        charStyles[n] = {
+          color: data.nameColor || 'deepskyblue',
+          font: data.nameFont || 'monospace'
+        };
+      }
+    });
+
+    function styledName(n, text) {
+      const style = charStyles[n] || { color: 'deepskyblue', font: 'monospace' };
+      return `<span class="char" style="color:${style.color}; font-family:${style.font}">${text}</span>`;
+    }
 
     function colorize(text) {
-      return text
+      text = text
         .replace(/#([\w ]+)/g, '<span class="item">#$1</span>')
         .replace(/\$(\d+)/g, '<span class="gold">$$$1</span>')
-        .replace(/@([\w ]+)/g, '<span class="char">@$1</span>')
+        .replace(/@([\w ]+)/g, (m, c) => styledName(c, '@' + c))
         .replace(/&([\w ]+)/g, '<span class="location">&$1</span>')
         .replace(/!([\w ]+)/g, '<span class="spell">!$1</span>')
         .replace(/%([\w ]+)/g, '<span class="monster">%$1</span>');
+      return text.replace(/\[Player\] ([^:]+):/, (m, p1) => `[Player] ${styledName(p1, p1)}:`);
     }
 
     socket.emit('getCampaignLog');

--- a/public/player_client.js
+++ b/public/player_client.js
@@ -258,6 +258,8 @@ window.onload = function () {
   }
 
   function finalizeCharacter() {
+    currentChar.nameColor = '#00bfff';
+    currentChar.nameFont = 'monospace';
     socket.emit('saveCharacter', currentChar);
     printMessage('Character creation complete!');
     phase = 'loading';
@@ -265,6 +267,8 @@ window.onload = function () {
 
   socket.on('characterLoaded', (charData) => {
     currentChar = charData;
+    if (!currentChar.nameColor) currentChar.nameColor = '#00bfff';
+    if (!currentChar.nameFont) currentChar.nameFont = 'monospace';
     printMessage(`Welcome back, ${charData.name}!`);
     localStorage.setItem('characterName', charData.name);
     showMenu();


### PR DESCRIPTION
## Summary
- let players choose a color and font for their name on the character sheet
- use chosen style when showing names in chat
- store default color and font on new characters

## Testing
- `npm test` *(fails: Missing script)*
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685ab5acf9688332a404bf16c7937a1f