### PR TITLE
Add customizable name style

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,14 +4,33 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>OSE RPG Entry</title>
+  <link id="themeStylesheet" rel="stylesheet" href="public/theme-classic.css" />
   <style>
-    body { background: black; color: lime; font-family: monospace; padding: 2rem; max-width: 600px; margin: 0 auto; font-size: 18px; line-height: 1.4; }
-    a { color: #00ffcc; display: block; margin: 1rem 0; }
+    body { font-family: monospace; padding: 2rem; max-width: 600px; margin: 0 auto; font-size: 18px; line-height: 1.4; background: var(--bg); color: var(--fg); }
+    a { color: var(--link); display: block; margin: 1rem 0; }
+    #themeSelect { margin-bottom: 1rem; }
   </style>
 </head>
 <body>
   <h1>OSE RPG - Welcome</h1>
+  <label for="themeSelect">Theme:</label>
+  <select id="themeSelect">
+    <option value="classic">Classic</option>
+    <option value="bw">Black & White</option>
+    <option value="modern">Modern</option>
+  </select>
   <p><a href="/player.html">▶ Join as Player</a></p>
   <p><a href="/dm.html">🎲 Launch GM Tools</a></p>
+  <script>
+    const sel = document.getElementById('themeSelect');
+    const saved = localStorage.getItem('theme') || 'classic';
+    sel.value = saved;
+    document.getElementById('themeStylesheet').href = `public/theme-${saved}.css`;
+    sel.onchange = () => {
+      const t = sel.value;
+      localStorage.setItem('theme', t);
+      document.getElementById('themeStylesheet').href = `public/theme-${t}.css`;
+    };
+  </script>
 </body>
 </html>

--- a/public/character.html
+++ b/public/character.html
@@ -4,32 +4,50 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Character Sheet</title>
+  <link id="themeStylesheet" rel="stylesheet" href="theme-classic.css" />
   <style>
     body {
-      background: black;
-      color: lime;
       font-family: monospace;
       padding: 1rem;
       margin: 0 auto;
       max-width: 600px;
       font-size: 18px;
       line-height: 1.4;
+      background: var(--bg);
+      color: var(--fg);
     }
-    a { color: #00ffcc; }
+    a { color: var(--link); }
     input, button {
-      background: black;
-      color: lime;
-      border: 1px solid lime;
+      background: var(--accent-bg);
+      color: var(--accent-fg);
+      border: 1px solid var(--border);
       font-family: monospace;
     }
+    #themeSelect { margin-bottom: 0.5rem; }
   </style>
 </head>
 <body>
+  <label for="themeSelect">Theme:</label>
+  <select id="themeSelect">
+    <option value="classic">Classic</option>
+    <option value="bw">Black & White</option>
+    <option value="modern">Modern</option>
+  </select>
   <div id="charDisplay">Loading...</div>
   <p><a href="player.html">&#x2B05; Back</a></p>
 
   <script src="/socket.io/socket.io.js"></script>
   <script>
+    const sel = document.getElementById('themeSelect');
+    const savedTheme = localStorage.getItem('theme') || 'classic';
+    sel.value = savedTheme;
+    document.getElementById('themeStylesheet').href = `theme-${savedTheme}.css`;
+    sel.onchange = () => {
+      const t = sel.value;
+      localStorage.setItem('theme', t);
+      document.getElementById('themeStylesheet').href = `theme-${t}.css`;
+    };
+
     const display = document.getElementById('charDisplay');
     const socket = io();
     const name = localStorage.getItem('characterName');
@@ -55,6 +73,24 @@
       return { slots, mv };
     }
 
+    const xpTable = {
+      Fighter: [0, 2000, 4000, 8000, 16000, 32000, 64000, 120000, 240000, 360000],
+      Cleric: [0, 1500, 3000, 6000, 12000, 24000, 48000, 90000, 180000, 270000],
+      'Magic-User': [0, 2500, 5000, 10000, 20000, 40000, 80000, 150000, 300000, 450000],
+      Thief: [0, 1200, 2400, 4800, 9600, 20000, 40000, 70000, 110000, 160000]
+    };
+    const hitDie = { Fighter: 8, Cleric: 6, 'Magic-User': 4, Thief: 4 };
+
+    function checkLevelUp(char) {
+      while (char.xp >= char.nextLevelXP) {
+        char.level = (char.level || 1) + 1;
+        const hd = hitDie[char.class] || 6;
+        char.hp += Math.floor(Math.random() * hd) + 1;
+        const next = xpTable[char.class][char.level] || Infinity;
+        char.nextLevelXP = next;
+      }
+    }
+
     let currentChar = null;
     socket.on('characterLoaded', (charData) => {
       currentChar = charData;
@@ -67,7 +103,7 @@
       ).join('');
       display.innerHTML =
         `<strong id="previewName" style="color:${currentChar.nameColor}; font-family:${currentChar.nameFont}">${charData.name}</strong><br>` +
-        `Class: ${charData.class} ${charData.alignment}<br>` +
+        `Class: ${charData.class} ${charData.alignment} Level ${charData.level}<br>` +
         `Career: ${charData.career || ''}<br>` +
         `STR:${s.STR} DEX:${s.DEX} CON:${s.CON} INT:${s.INT} WIS:${s.WIS} CHA:${s.CHA}<br>` +
         `HP:<input id="hpInput" type="number" value="${charData.hp}" style="width:60px"> ` +
@@ -95,6 +131,7 @@
         currentChar.xp = parseInt(document.getElementById('xpInput').value, 10);
         currentChar.nameColor = colorInput.value;
         currentChar.nameFont = fontSelect.value;
+        checkLevelUp(currentChar);
         socket.emit('saveCharacter', currentChar);
         alert('Character saved');
       };

--- a/public/character.html
+++ b/public/character.html
@@ -58,9 +58,15 @@
     let currentChar = null;
     socket.on('characterLoaded', (charData) => {
       currentChar = charData;
+      if (!currentChar.nameColor) currentChar.nameColor = '#00bfff';
+      if (!currentChar.nameFont) currentChar.nameFont = 'monospace';
       const s = charData.stats || {};
+      const fonts = ['monospace','serif','sans-serif','cursive','fantasy'];
+      const fontOptions = fonts.map(f =>
+        `<option value="${f}"${currentChar.nameFont===f?' selected':''}>${f}</option>`
+      ).join('');
       display.innerHTML =
-        `<strong>${charData.name}</strong><br>` +
+        `<strong id="previewName" style="color:${currentChar.nameColor}; font-family:${currentChar.nameFont}">${charData.name}</strong><br>` +
         `Class: ${charData.class} ${charData.alignment}<br>` +
         `Career: ${charData.career || ''}<br>` +
         `STR:${s.STR} DEX:${s.DEX} CON:${s.CON} INT:${s.INT} WIS:${s.WIS} CHA:${s.CHA}<br>` +
@@ -71,11 +77,24 @@
           const enc = encumbrance(charData);
           return `ENC:${enc.slots} MV:${enc.mv}<br>`;
         })() +
+        `Name Color: <input id="colorInput" type="color" value="${currentChar.nameColor}"><br>` +
+        `Name Font: <select id="fontSelect">${fontOptions}</select><br>` +
         `<button id="saveBtn">Save</button>`;
+
+      const colorInput = document.getElementById('colorInput');
+      const fontSelect = document.getElementById('fontSelect');
+      colorInput.oninput = () => {
+        document.getElementById('previewName').style.color = colorInput.value;
+      };
+      fontSelect.onchange = () => {
+        document.getElementById('previewName').style.fontFamily = fontSelect.value;
+      };
 
       document.getElementById('saveBtn').onclick = () => {
         currentChar.hp = parseInt(document.getElementById('hpInput').value, 10);
         currentChar.xp = parseInt(document.getElementById('xpInput').value, 10);
+        currentChar.nameColor = colorInput.value;
+        currentChar.nameFont = fontSelect.value;
         socket.emit('saveCharacter', currentChar);
         alert('Character saved');
       };

--- a/public/chat.html
+++ b/public/chat.html
@@ -4,35 +4,52 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Chat</title>
+  <link id="themeStylesheet" rel="stylesheet" href="theme-classic.css" />
   <style>
     body {
-      background: black;
-      color: lime;
       font-family: monospace;
       padding: 1rem;
       margin: 0 auto;
       max-width: 600px;
       font-size: 18px;
       line-height: 1.4;
+      background: var(--bg);
+      color: var(--fg);
     }
-    a { color: #00ffcc; }
-    pre { height: 60vh; overflow-y: auto; white-space: pre-wrap; border: 1px solid #0f0; padding: 0.5rem; }
+    a { color: var(--link); }
+    pre { height: 60vh; overflow-y: auto; white-space: pre-wrap; border: 1px solid var(--border); padding: 0.5rem; }
     .char { color: deepskyblue; }
     .location { color: violet; }
     .item { color: gold; }
     .spell { color: orchid; }
     .monster { color: tomato; }
     .gold { color: khaki; }
-    input { width: 100%; font-size: 18px; margin-top: 0.5rem; }
+    input { width: 100%; font-size: 18px; margin-top: 0.5rem; background: var(--accent-bg); color: var(--accent-fg); border: 1px solid var(--border); }
+    #themeSelect { margin-bottom: 0.5rem; }
   </style>
 </head>
 <body>
+  <label for="themeSelect">Theme:</label>
+  <select id="themeSelect">
+    <option value="classic">Classic</option>
+    <option value="bw">Black & White</option>
+    <option value="modern">Modern</option>
+  </select>
   <pre id="log"></pre>
   <input id="chatInput" placeholder="message" autocomplete="off" />
   <p><a href="player.html">&#x2B05; Back</a></p>
 
   <script src="/socket.io/socket.io.js"></script>
   <script>
+    const sel = document.getElementById('themeSelect');
+    const saved = localStorage.getItem('theme') || 'classic';
+    sel.value = saved;
+    document.getElementById('themeStylesheet').href = `theme-${saved}.css`;
+    sel.onchange = () => {
+      const t = sel.value;
+      localStorage.setItem('theme', t);
+      document.getElementById('themeStylesheet').href = `theme-${t}.css`;
+    };
     const socket = io();
     const logEl = document.getElementById('log');
     const input = document.getElementById('chatInput');

--- a/public/chat.html
+++ b/public/chat.html
@@ -37,15 +37,33 @@
     const logEl = document.getElementById('log');
     const input = document.getElementById('chatInput');
     const name = localStorage.getItem('characterName') || 'Anon';
+    let charStyles = {};
+
+    socket.emit('loadAllCharacters');
+    socket.on('allCharacters', (chars) => {
+      charStyles = {};
+      for (const [n, data] of Object.entries(chars)) {
+        charStyles[n] = {
+          color: data.nameColor || 'deepskyblue',
+          font: data.nameFont || 'monospace'
+        };
+      }
+    });
+
+    function styledName(n, text) {
+      const style = charStyles[n] || { color: 'deepskyblue', font: 'monospace' };
+      return `<span class="char" style="color:${style.color}; font-family:${style.font}">${text}</span>`;
+    }
 
     function colorize(text) {
-      return text
+      text = text
         .replace(/#([\w ]+)/g, '<span class="item">#$1</span>')
         .replace(/\$(\d+)/g, '<span class="gold">$$$1</span>')
-        .replace(/@([\w ]+)/g, '<span class="char">@$1</span>')
+        .replace(/@([\w ]+)/g, (m, c) => styledName(c, '@' + c))
         .replace(/&([\w ]+)/g, '<span class="location">&$1</span>')
         .replace(/!([\w ]+)/g, '<span class="spell">!$1</span>')
         .replace(/%([\w ]+)/g, '<span class="monster">%$1</span>');
+      return text.replace(/\[Player\] ([^:]+):/, (m, p1) => `[Player] ${styledName(p1, p1)}:`);
     }
 
     socket.emit('getCampaignLog');

--- a/public/dm.html
+++ b/public/dm.html
@@ -4,19 +4,20 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>OSE RPG - GM Tools</title>
+  <link id="themeStylesheet" rel="stylesheet" href="theme-classic.css" />
   <style>
     body {
-      background: black;
-      color: lime;
       font-family: monospace;
       margin: 0 auto;
       max-width: 600px;
       padding: 1rem;
       font-size: 18px;
       line-height: 1.4;
+      background: var(--bg);
+      color: var(--fg);
     }
     canvas {
-      border: 1px solid lime;
+      border: 1px solid var(--border);
     }
     .char { color: deepskyblue; }
     .location { color: violet; }
@@ -24,9 +25,16 @@
     .spell { color: orchid; }
     .monster { color: tomato; }
     .gold { color: khaki; }
+    #themeSelect { margin-bottom: 0.5rem; }
   </style>
 </head>
 <body>
+  <label for="themeSelect">Theme:</label>
+  <select id="themeSelect">
+    <option value="classic">Classic</option>
+    <option value="bw">Black & White</option>
+    <option value="modern">Modern</option>
+  </select>
   <h1>OSE RPG GM Interface</h1>
   <pre id="menuDisplay"></pre>
   <input id="gmInput" autocomplete="off" />
@@ -35,5 +43,16 @@
 
   <script src="/socket.io/socket.io.js"></script>
   <script src="gm_menu.js"></script>
+  <script>
+    const sel = document.getElementById('themeSelect');
+    const saved = localStorage.getItem('theme') || 'classic';
+    sel.value = saved;
+    document.getElementById('themeStylesheet').href = `theme-${saved}.css`;
+    sel.onchange = () => {
+      const t = sel.value;
+      localStorage.setItem('theme', t);
+      document.getElementById('themeStylesheet').href = `theme-${t}.css`;
+    };
+  </script>
 </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -4,23 +4,42 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>OSE RPG Entry</title>
+  <link id="themeStylesheet" rel="stylesheet" href="theme-classic.css" />
   <style>
     body {
-      background: black;
-      color: lime;
       font-family: monospace;
       padding: 2rem;
       max-width: 600px;
       margin: 0 auto;
       font-size: 18px;
       line-height: 1.4;
+      background: var(--bg);
+      color: var(--fg);
     }
-    a { color: #00ffcc; display: block; margin: 1rem 0; }
+    a { color: var(--link); display: block; margin: 1rem 0; }
+    #themeSelect { margin-bottom: 1rem; }
   </style>
 </head>
 <body>
   <h1>OSE RPG - Welcome</h1>
+  <label for="themeSelect">Theme:</label>
+  <select id="themeSelect">
+    <option value="classic">Classic</option>
+    <option value="bw">Black & White</option>
+    <option value="modern">Modern</option>
+  </select>
   <p><a href="/player.html">▶ Join as Player</a></p>
   <p><a href="/dm.html">🎲 Launch GM Tools</a></p>
+  <script>
+    const sel = document.getElementById('themeSelect');
+    const saved = localStorage.getItem('theme') || 'classic';
+    sel.value = saved;
+    document.getElementById('themeStylesheet').href = `theme-${saved}.css`;
+    sel.onchange = () => {
+      const t = sel.value;
+      localStorage.setItem('theme', t);
+      document.getElementById('themeStylesheet').href = `theme-${t}.css`;
+    };
+  </script>
 </body>
 </html>

--- a/public/items.html
+++ b/public/items.html
@@ -4,26 +4,43 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Items</title>
+  <link id="themeStylesheet" rel="stylesheet" href="theme-classic.css" />
   <style>
     body {
-      background: black;
-      color: lime;
       font-family: monospace;
       padding: 1rem;
       margin: 0 auto;
       max-width: 600px;
       font-size: 18px;
       line-height: 1.4;
+      background: var(--bg);
+      color: var(--fg);
     }
-    a { color: #00ffcc; }
+    a { color: var(--link); }
+    #themeSelect { margin-bottom: 0.5rem; }
   </style>
 </head>
 <body>
+  <label for="themeSelect">Theme:</label>
+  <select id="themeSelect">
+    <option value="classic">Classic</option>
+    <option value="bw">Black & White</option>
+    <option value="modern">Modern</option>
+  </select>
   <pre id="itemsDisplay">Loading...</pre>
   <p><a href="player.html">&#x2B05; Back</a></p>
 
   <script src="/socket.io/socket.io.js"></script>
   <script>
+    const sel = document.getElementById('themeSelect');
+    const saved = localStorage.getItem('theme') || 'classic';
+    sel.value = saved;
+    document.getElementById('themeStylesheet').href = `theme-${saved}.css`;
+    sel.onchange = () => {
+      const t = sel.value;
+      localStorage.setItem('theme', t);
+      document.getElementById('themeStylesheet').href = `theme-${t}.css`;
+    };
     const display = document.getElementById('itemsDisplay');
     const socket = io();
     const name = localStorage.getItem('characterName');

--- a/public/journal.html
+++ b/public/journal.html
@@ -4,19 +4,21 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Journal</title>
+  <link id="themeStylesheet" rel="stylesheet" href="theme-classic.css" />
   <style>
     body {
-      background: black;
-      color: lime;
       font-family: monospace;
       padding: 1rem;
       margin: 0 auto;
       max-width: 600px;
       font-size: 18px;
       line-height: 1.4;
+      background: var(--bg);
+      color: var(--fg);
     }
-    a { color: #00ffcc; }
+    a { color: var(--link); }
     pre { white-space: pre-wrap; }
+    #themeSelect { margin-bottom: 0.5rem; }
     .char { color: deepskyblue; }
     .location { color: violet; }
     .item { color: gold; }
@@ -26,11 +28,26 @@
   </style>
 </head>
 <body>
+  <label for="themeSelect">Theme:</label>
+  <select id="themeSelect">
+    <option value="classic">Classic</option>
+    <option value="bw">Black & White</option>
+    <option value="modern">Modern</option>
+  </select>
   <pre id="journal">Loading...</pre>
   <p><a href="player.html">&#x2B05; Back</a></p>
 
   <script src="/socket.io/socket.io.js"></script>
   <script>
+    const sel = document.getElementById('themeSelect');
+    const saved = localStorage.getItem('theme') || 'classic';
+    sel.value = saved;
+    document.getElementById('themeStylesheet').href = `theme-${saved}.css`;
+    sel.onchange = () => {
+      const t = sel.value;
+      localStorage.setItem('theme', t);
+      document.getElementById('themeStylesheet').href = `theme-${t}.css`;
+    };
     const display = document.getElementById('journal');
     const socket = io();
     function colorize(text) {

--- a/public/map.html
+++ b/public/map.html
@@ -4,27 +4,44 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Map</title>
+  <link id="themeStylesheet" rel="stylesheet" href="theme-classic.css" />
   <style>
     body {
-      background: black;
-      color: lime;
       font-family: monospace;
       padding: 1rem;
       margin: 0 auto;
       max-width: 600px;
       font-size: 18px;
       line-height: 1.4;
+      background: var(--bg);
+      color: var(--fg);
     }
-    a { color: #00ffcc; }
+    a { color: var(--link); }
     pre { white-space: pre-wrap; }
+    #themeSelect { margin-bottom: 0.5rem; }
   </style>
 </head>
 <body>
+  <label for="themeSelect">Theme:</label>
+  <select id="themeSelect">
+    <option value="classic">Classic</option>
+    <option value="bw">Black & White</option>
+    <option value="modern">Modern</option>
+  </select>
   <pre id="mapDisplay">Loading...</pre>
   <p><a href="player.html">&#x2B05; Back</a></p>
 
   <script src="/socket.io/socket.io.js"></script>
   <script>
+    const sel = document.getElementById('themeSelect');
+    const saved = localStorage.getItem('theme') || 'classic';
+    sel.value = saved;
+    document.getElementById('themeStylesheet').href = `theme-${saved}.css`;
+    sel.onchange = () => {
+      const t = sel.value;
+      localStorage.setItem('theme', t);
+      document.getElementById('themeStylesheet').href = `theme-${t}.css`;
+    };
     const display = document.getElementById('mapDisplay');
     const socket = io();
     socket.emit('getMap');

--- a/public/player.html
+++ b/public/player.html
@@ -4,24 +4,25 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>OSE RPG - Player</title>
+  <link id="themeStylesheet" rel="stylesheet" href="theme-classic.css" />
   <style>
     body {
-      background: black;
-      color: lime;
       font-family: monospace;
       margin: 0 auto;
       padding: 1rem;
       max-width: 600px;
       font-size: 18px;
       line-height: 1.4;
+      background: var(--bg);
+      color: var(--fg);
     }
     #gameDisplay {
       width: 100%;
       height: 70vh;
-      background: #000;
-      color: #0f0;
+      background: var(--accent-bg);
+      color: var(--accent-fg);
       font-size: 18px;
-      border: 1px solid #0f0;
+      border: 1px solid var(--border);
       padding: 1rem;
       white-space: pre-wrap;
       overflow-y: auto;
@@ -30,18 +31,36 @@
       width: 100%;
       font-size: 18px;
       padding: 0.5rem;
-      border: 1px solid #0f0;
-      background: black;
-      color: lime;
+      border: 1px solid var(--border);
+      background: var(--accent-bg);
+      color: var(--accent-fg);
     }
+    #themeSelect { margin-bottom: 0.5rem; }
   </style>
 </head>
 <body>
+  <label for="themeSelect">Theme:</label>
+  <select id="themeSelect">
+    <option value="classic">Classic</option>
+    <option value="bw">Black & White</option>
+    <option value="modern">Modern</option>
+  </select>
   <div id="gameDisplay">Welcome, adventurer!
 Enter your name:</div>
   <input id="commandInput" placeholder=">" autocomplete="off" autofocus>
 
   <script src="/socket.io/socket.io.js"></script>
   <script type="module" src="player_client.js"></script>
+  <script>
+    const sel = document.getElementById('themeSelect');
+    const saved = localStorage.getItem('theme') || 'classic';
+    sel.value = saved;
+    document.getElementById('themeStylesheet').href = `theme-${saved}.css`;
+    sel.onchange = () => {
+      const t = sel.value;
+      localStorage.setItem('theme', t);
+      document.getElementById('themeStylesheet').href = `theme-${t}.css`;
+    };
+  </script>
 </body>
 </html>

--- a/public/player_client.js
+++ b/public/player_client.js
@@ -20,6 +20,13 @@ window.onload = function () {
     { name: 'Soldier', items: ['spear', 'shield'] },
     { name: 'Urchin', items: ['dagger', 'rat on a string'] }
   ];
+  const xpTable = {
+    Fighter: [0, 2000, 4000, 8000, 16000, 32000, 64000, 120000, 240000, 360000],
+    Cleric: [0, 1500, 3000, 6000, 12000, 24000, 48000, 90000, 180000, 270000],
+    'Magic-User': [0, 2500, 5000, 10000, 20000, 40000, 80000, 150000, 300000, 450000],
+    Thief: [0, 1200, 2400, 4800, 9600, 20000, 40000, 70000, 110000, 160000]
+  };
+  const hitDie = { Fighter: 8, Cleric: 6, 'Magic-User': 4, Thief: 4 };
   const shopItems = [
     // Adventuring gear
     { name: 'Rations (1 day)', cost: 5 },
@@ -95,7 +102,7 @@ window.onload = function () {
       `STR:${s.STR} DEX:${s.DEX} CON:${s.CON} INT:${s.INT} WIS:${s.WIS} CHA:${s.CHA}`
     );
     printMessage(
-      `HP:${currentChar.hp} AC:${currentChar.ac} XP:${currentChar.xp}/${currentChar.nextLevelXP}`
+      `Level:${currentChar.level} HP:${currentChar.hp} AC:${currentChar.ac} XP:${currentChar.xp}/${currentChar.nextLevelXP}`
     );
     const enc = encumbrance(currentChar);
     printMessage(`ENC:${enc.slots} MV:${enc.mv}`);
@@ -169,10 +176,12 @@ window.onload = function () {
           WIS: rollStat(),
           CHA: rollStat()
         };
-        currentChar.hp = Math.floor(Math.random() * 6) + 1;
+        const hd = hitDie[currentChar.class] || 6;
+        currentChar.level = 1;
+        currentChar.hp = Math.floor(Math.random() * hd) + 1;
         currentChar.ac = 9;
         currentChar.xp = 0;
-        currentChar.nextLevelXP = 2000;
+        currentChar.nextLevelXP = xpTable[currentChar.class][1];
         const roll = () => Math.floor(Math.random() * 6) + 1;
         currentChar.gold = (roll() + roll() + roll()) * 10;
         printMessage(`Stats rolled: STR ${currentChar.stats.STR}, DEX ${currentChar.stats.DEX}, CON ${currentChar.stats.CON}, INT ${currentChar.stats.INT}, WIS ${currentChar.stats.WIS}, CHA ${currentChar.stats.CHA}`);

--- a/public/player_client.js
+++ b/public/player_client.js
@@ -258,6 +258,8 @@ window.onload = function () {
   }
 
   function finalizeCharacter() {
+    currentChar.nameColor = '#00bfff';
+    currentChar.nameFont = 'monospace';
     socket.emit('saveCharacter', currentChar);
     printMessage('Character creation complete!');
     phase = 'loading';
@@ -265,6 +267,8 @@ window.onload = function () {
 
   socket.on('characterLoaded', (charData) => {
     currentChar = charData;
+    if (!currentChar.nameColor) currentChar.nameColor = '#00bfff';
+    if (!currentChar.nameFont) currentChar.nameFont = 'monospace';
     printMessage(`Welcome back, ${charData.name}!`);
     localStorage.setItem('characterName', charData.name);
     showMenu();

--- a/public/theme-bw.css
+++ b/public/theme-bw.css
@@ -1,0 +1,8 @@
+:root {
+  --bg: white;
+  --fg: black;
+  --link: blue;
+  --border: black;
+  --accent-bg: white;
+  --accent-fg: black;
+}

--- a/public/theme-classic.css
+++ b/public/theme-classic.css
@@ -1,0 +1,8 @@
+:root {
+  --bg: black;
+  --fg: lime;
+  --link: #00ffcc;
+  --border: lime;
+  --accent-bg: black;
+  --accent-fg: lime;
+}

--- a/public/theme-modern.css
+++ b/public/theme-modern.css
@@ -1,0 +1,8 @@
+:root {
+  --bg: #1e1e1e;
+  --fg: #d4d4d4;
+  --link: #9cdcfe;
+  --border: #9cdcfe;
+  --accent-bg: #2e2e2e;
+  --accent-fg: #d4d4d4;
+}


### PR DESCRIPTION
## Summary
- let players choose a color and font for their name on the character sheet
- use chosen style when showing names in chat
- store default color and font on new characters

## Testing
- `npm test` *(fails: Missing script)*
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685ab5acf9688332a404bf16c7937a1f