### PR TITLE
Enhance player menus with spells and inventory info

### DIFF
--- a/public/character.html
+++ b/public/character.html
@@ -103,10 +103,6 @@
         `HP:<input id="hpInput" type="number" value="${charData.hp}" style="width:60px"> ` +
         `AC:${charData.ac} ` +
         `XP:<input id="xpInput" type="number" value="${charData.xp}" style="width:80px">/${charData.nextLevelXP}<br>` +
-        (() => {
-          const enc = encumbrance(charData);
-          return `ENC:${enc.slots} MV:${enc.mv}<br>`;
-        })() +
         `<button id="saveBtn">Save</button>`;
 
       document.getElementById('saveBtn').onclick = () => {

--- a/public/chat.html
+++ b/public/chat.html
@@ -18,6 +18,8 @@
     }
     a { color: var(--link); }
     pre { height: 60vh; overflow-y: auto; white-space: pre-wrap; border: 1px solid var(--border); padding: 0.5rem; }
+    .readyBar { border: 1px solid var(--border); padding: 0.25rem; margin-top: 0.5rem; display: flex; flex-wrap: wrap; gap: 0.25rem; }
+    .readyBar span { white-space: nowrap; }
     .char { color: deepskyblue; }
     .location { color: violet; }
     .item { color: gold; }
@@ -36,7 +38,7 @@
     <option value="modern">Modern</option>
   </select>
   <pre id="log"></pre>
-  <pre id="readyBox"></pre>
+  <div id="readyBox" class="readyBar"></div>
   <input id="chatInput" placeholder="message" autocomplete="off" />
   <p><a href="player.html">&#x2B05; Back</a></p>
 
@@ -77,9 +79,9 @@
       logEl.scrollTop = logEl.scrollHeight;
     });
     socket.on('readyList', (list) => {
-      readyBox.textContent = Object.entries(list)
-        .map(([n, r]) => `${r ? '[READY]' : '[    ]'} ${n}`)
-        .join('\n');
+      readyBox.innerHTML = Object.entries(list)
+        .map(([n, r]) => `<span>${r ? '[READY]' : '[    ]'} ${n}</span>`)
+        .join(' ');
     });
     function roll(expr) {
       const m = expr.match(/(\d*)d(\d+)([+-]\d+)?/i);

--- a/public/player_client.js
+++ b/public/player_client.js
@@ -89,6 +89,7 @@ window.onload = function () {
         '4. Chat\n' +
         '5. Journal\n' +
         '6. Help\n' +
+        '7. Spells\n' +
         '(Selecting an option opens a new page)'
     );
     phase = 'menu';
@@ -117,13 +118,15 @@ window.onload = function () {
     printMessage(
       `Level:${currentChar.level} HP:${currentChar.hp} AC:${currentChar.ac} XP:${currentChar.xp}/${currentChar.nextLevelXP}`
     );
-    const enc = encumbrance(currentChar);
-    printMessage(`ENC:${enc.slots} MV:${enc.mv}`);
     showMenu();
   }
 
   function showItems() {
-    printMessage('Items: ' + (currentChar.inventory || []).join(', '));
+    const enc = encumbrance(currentChar);
+    printMessage(
+      'Items: ' + (currentChar.inventory || []).join(', ') +
+      `\nGold: ${currentChar.gold || 0}\nENC:${enc.slots} MV:${enc.mv}`
+    );
     showMenu();
   }
 
@@ -256,6 +259,9 @@ window.onload = function () {
           break;
         case '6':
           showHelp();
+          break;
+        case '7':
+          window.location.href = 'spells.html';
           break;
         default:
           printMessage('Invalid choice.');

--- a/public/spells.html
+++ b/public/spells.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Items</title>
+  <title>Spells</title>
   <link id="themeStylesheet" rel="stylesheet" href="theme-classic.css" />
   <style>
     body {
@@ -27,7 +27,7 @@
     <option value="bw">Black & White</option>
     <option value="modern">Modern</option>
   </select>
-  <pre id="itemsDisplay">Loading...</pre>
+  <pre id="spellDisplay">Loading...</pre>
   <p><a href="player.html">&#x2B05; Back</a></p>
 
   <script src="/socket.io/socket.io.js"></script>
@@ -41,7 +41,7 @@
       localStorage.setItem('theme', t);
       document.getElementById('themeStylesheet').href = `theme-${t}.css`;
     };
-    const display = document.getElementById('itemsDisplay');
+    const display = document.getElementById('spellDisplay');
     const socket = io();
     const name = localStorage.getItem('characterName');
     if (name) {
@@ -49,27 +49,8 @@
     } else {
       display.textContent = 'No character found.';
     }
-    function encumbrance(char) {
-      let slots = (char.inventory || []).length;
-      const coins = char.gold || 0;
-      slots += Math.ceil(coins / 100);
-      if ((char.inventory || []).includes('Plate Mail')) slots += 5;
-      if ((char.inventory || []).includes('Chain Mail')) slots += 4;
-      if ((char.inventory || []).includes('Leather Armor')) slots += 2;
-      if ((char.inventory || []).includes('Shield')) slots += 1;
-      let mv;
-      if (slots <= 5) mv = '120\'';
-      else if (slots <= 10) mv = '90\'';
-      else if (slots <= 15) mv = '60\'';
-      else mv = '30\'';
-      return { slots, mv };
-    }
     socket.on('characterLoaded', (charData) => {
-      const enc = encumbrance(charData);
-      display.textContent =
-        'Items:\n' +
-        (charData.inventory || []).join('\n') +
-        `\nGold: ${charData.gold || 0}\nENC:${enc.slots} MV:${enc.mv}`;
+      display.textContent = 'Spells:\n' + (charData.spells || []).join('\n');
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add gold and encumbrance readout to items page and items command
- remove encumbrance from character sheet
- add spells page and menu option
- improve ready bar styling on chat page

## Testing
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685abf9082608332a6135702e17b76f3