### PR TITLE
Add DM dialogue types and player save

### DIFF
--- a/public/chat.html
+++ b/public/chat.html
@@ -26,6 +26,9 @@
     .spell { color: orchid; }
     .monster { color: tomato; }
     .gold { color: khaki; }
+    .gmchar { color: lightgreen; }
+    .gmevent { color: orange; }
+    .gmstory { color: plum; }
     input { width: 100%; font-size: 18px; margin-top: 0.5rem; background: var(--accent-bg); color: var(--accent-fg); border: 1px solid var(--border); }
     #themeSelect { margin-bottom: 0.5rem; }
   </style>
@@ -60,6 +63,9 @@
     const name = localStorage.getItem('characterName') || 'Anon';
 
     function colorize(text) {
+      if (text.startsWith('[CHAR]')) return '<span class="gmchar">' + text + '</span>';
+      if (text.startsWith('[EVENT]')) return '<span class="gmevent">' + text + '</span>';
+      if (text.startsWith('[STORY]')) return '<span class="gmstory">' + text + '</span>';
       return text
         .replace(/#([\w ]+)/g, '<span class="item">#$1</span>')
         .replace(/\$(\d+)/g, '<span class="gold">$$$1</span>')

--- a/public/dm.html
+++ b/public/dm.html
@@ -28,6 +28,9 @@
     .spell { color: orchid; }
     .monster { color: tomato; }
     .gold { color: khaki; }
+    .gmchar { color: lightgreen; }
+    .gmevent { color: orange; }
+    .gmstory { color: plum; }
     #themeSelect { margin-bottom: 0.5rem; }
   </style>
 </head>
@@ -48,6 +51,7 @@
   <div id="mapControls" style="display:none">
     Map Name: <input id="mapName" />
     <button id="saveMapBtn">Save Map</button>
+    <button id="newMapBtn">New Map</button>
   </div>
 
   <script src="/socket.io/socket.io.js"></script>

--- a/public/gm_menu.js
+++ b/public/gm_menu.js
@@ -7,6 +7,7 @@ const palette = document.getElementById('tilePalette');
 const mapControls = document.getElementById('mapControls');
 const mapNameInput = document.getElementById('mapName');
 const saveMapBtn = document.getElementById('saveMapBtn');
+const newMapBtn = document.getElementById('newMapBtn');
 const readyDisplay = document.getElementById('readyDisplay');
 const ctx = canvas.getContext('2d');
 const cellSize = TILE_SIZE;
@@ -38,6 +39,9 @@ function buildPalette() {
 }
 
 function colorize(text) {
+  if (text.startsWith('[CHAR]')) return '<span class="gmchar">' + text + '</span>';
+  if (text.startsWith('[EVENT]')) return '<span class="gmevent">' + text + '</span>';
+  if (text.startsWith('[STORY]')) return '<span class="gmstory">' + text + '</span>';
   return text
     .replace(/#([\w ]+)/g, '<span class="item">#$1</span>')
     .replace(/\$(\d+)/g, '<span class="gold">$$$1</span>')
@@ -54,7 +58,10 @@ function showMainMenu() {
     '2. Map Menu\n' +
     '3. Campaign log\n' +
     '4. Send DM message\n' +
-    '5. Help';
+    '5. Character dialogue\n' +
+    '6. Event dialogue\n' +
+    '7. Story dialogue\n' +
+    '8. Help';
   canvas.style.display = 'none';
   palette.style.display = 'none';
   mapControls.style.display = 'none';
@@ -129,6 +136,18 @@ function handleInput(text) {
         mode = 'dmmsg';
         break;
       case '5':
+        display.textContent = 'Enter character dialogue:';
+        mode = 'chard';
+        break;
+      case '6':
+        display.textContent = 'Enter event dialogue:';
+        mode = 'eventd';
+        break;
+      case '7':
+        display.textContent = 'Enter story dialogue:';
+        mode = 'storyd';
+        break;
+      case '8':
         display.textContent =
           'GM Help:\n/ready players send /ready or /unready in chat to toggle status.' +
           '\nUse menu numbers to access tools.\n0. Return';
@@ -198,6 +217,15 @@ function handleInput(text) {
     showMainMenu();
   } else if (mode === 'dmmsg') {
     socket.emit('dmMessage', text);
+    showMainMenu();
+  } else if (mode === 'chard') {
+    socket.emit('gmChar', text);
+    showMainMenu();
+  } else if (mode === 'eventd') {
+    socket.emit('gmEvent', text);
+    showMainMenu();
+  } else if (mode === 'storyd') {
+    socket.emit('gmStory', text);
     showMainMenu();
   } else if (mode === 'log') {
     if (text === '0') showMainMenu();
@@ -291,7 +319,13 @@ canvas.addEventListener('click', (ev) => {
 saveMapBtn.addEventListener('click', () => {
   const name = mapNameInput.value.trim() || mapName || 'unnamed';
   mapName = name;
-  socket.emit('saveMap', { name, data: mapData });
+socket.emit('saveMap', { name, data: mapData });
+});
+
+newMapBtn.addEventListener('click', () => {
+  mapData = Array.from({ length: 20 }, () => Array(20).fill(TILES[0]));
+  mapName = '';
+  drawMap();
 });
 
 (async () => {

--- a/public/journal.html
+++ b/public/journal.html
@@ -25,6 +25,9 @@
     .spell { color: orchid; }
     .monster { color: tomato; }
     .gold { color: khaki; }
+    .gmchar { color: lightgreen; }
+    .gmevent { color: orange; }
+    .gmstory { color: plum; }
   </style>
 </head>
 <body>
@@ -51,6 +54,9 @@
     const display = document.getElementById('journal');
     const socket = io();
     function colorize(text) {
+      if (text.startsWith('[CHAR]')) return '<span class="gmchar">' + text + '</span>';
+      if (text.startsWith('[EVENT]')) return '<span class="gmevent">' + text + '</span>';
+      if (text.startsWith('[STORY]')) return '<span class="gmstory">' + text + '</span>';
       return text
         .replace(/#([\w ]+)/g, '<span class="item">#$1</span>')
         .replace(/\$(\d+)/g, '<span class="gold">$$$1</span>')

--- a/public/player_client.js
+++ b/public/player_client.js
@@ -90,6 +90,7 @@ window.onload = function () {
         '5. Journal\n' +
         '6. Help\n' +
         '7. Spells\n' +
+        '8. Save Character\n' +
         '(Selecting an option opens a new page)'
     );
     phase = 'menu';
@@ -262,6 +263,10 @@ window.onload = function () {
           break;
         case '7':
           window.location.href = 'spells.html';
+          break;
+        case '8':
+          socket.emit('saveCharacter', currentChar);
+          printMessage('Character saved.');
           break;
         default:
           printMessage('Invalid choice.');

--- a/server.js
+++ b/server.js
@@ -162,6 +162,27 @@ io.on("connection", (socket) => {
     io.emit("logUpdate", entry);
   });
 
+  socket.on("gmChar", (message) => {
+    const entry = `[CHAR] ${message}`;
+    campaignLog.push(entry);
+    fs.appendFile(LOG_FILE, entry + "\n", () => {});
+    io.emit("logUpdate", entry);
+  });
+
+  socket.on("gmEvent", (message) => {
+    const entry = `[EVENT] ${message}`;
+    campaignLog.push(entry);
+    fs.appendFile(LOG_FILE, entry + "\n", () => {});
+    io.emit("logUpdate", entry);
+  });
+
+  socket.on("gmStory", (message) => {
+    const entry = `[STORY] ${message}`;
+    campaignLog.push(entry);
+    fs.appendFile(LOG_FILE, entry + "\n", () => {});
+    io.emit("logUpdate", entry);
+  });
+
   socket.on("getCampaignLog", () => {
     socket.emit("campaignLog", campaignLog);
   });


### PR DESCRIPTION
## Summary
- allow players to manually save their character
- extend GM menu with dialogue commands and new map button
- broadcast character, event and story dialogue
- colorize new dialogue types in chat and journal pages

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685ad49d23a88332b1d1d00409536bc4