### PR TITLE
Add lore book and GM controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ OSE RPG Full Bundle
 - Select **New map** for a blank map or **Map list** to load one to edit.
 - Use the map controls to name and **Save Map**.
 - Choose **Share map** to show a saved map to the players.
+
+**Lore Book**
+- Players can open the lore book from the main menu to view campaign lore.
+- The GM can add entries from the GM menu using **Add Lore**.

--- a/lore.json
+++ b/lore.json
@@ -1,0 +1,6 @@
+{
+  "characters": [],
+  "deaths": [],
+  "events": [],
+  "locations": []
+}

--- a/public/gm_menu.js
+++ b/public/gm_menu.js
@@ -61,7 +61,8 @@ function showMainMenu() {
     '5. Character dialogue\n' +
     '6. Event dialogue\n' +
     '7. Story dialogue\n' +
-    '8. Help';
+    '8. Help\n' +
+    '9. Add Lore';
   canvas.style.display = 'none';
   palette.style.display = 'none';
   mapControls.style.display = 'none';
@@ -150,6 +151,10 @@ function handleInput(text) {
           '\nUse menu numbers to access tools.\n0. Return';
         mode = 'help';
         break;
+      case '9':
+        display.textContent = 'Add Lore\n1. Characters\n2. Deaths\n3. Events\n4. Locations';
+        mode = 'loreChapter';
+        break;
       default:
         showMainMenu();
     }
@@ -225,6 +230,32 @@ function handleInput(text) {
     if (text === '0') {
       showMainMenu();
     }
+  } else if (mode === 'loreChapter') {
+    switch (text) {
+      case '1':
+        display.textContent = 'Enter lore for Characters:';
+        mode = 'loreEntryCharacters';
+        break;
+      case '2':
+        display.textContent = 'Enter lore for Deaths:';
+        mode = 'loreEntryDeaths';
+        break;
+      case '3':
+        display.textContent = 'Enter lore for Events:';
+        mode = 'loreEntryEvents';
+        break;
+      case '4':
+        display.textContent = 'Enter lore for Locations:';
+        mode = 'loreEntryLocations';
+        break;
+      default:
+        showMainMenu();
+    }
+  } else if (mode.startsWith('loreEntry')) {
+    const chapter = mode.replace('loreEntry', '').toLowerCase();
+    socket.emit('addLore', { chapter, text });
+    display.textContent = 'Lore added.';
+    mode = 'help';
   } else if (mode === 'loadmap') {
     socket.emit('loadMap', text);
     mapName = text;

--- a/public/lore.html
+++ b/public/lore.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Lore Book</title>
+  <link id="themeStylesheet" rel="stylesheet" href="theme-classic.css" />
+  <style>
+    body {
+      font-family: monospace;
+      padding: 1rem;
+      margin: 0 auto;
+      max-width: 600px;
+      font-size: 18px;
+      line-height: 1.4;
+      background: var(--bg);
+      color: var(--fg);
+    }
+    a { color: var(--link); }
+    #themeSelect { margin-bottom: 0.5rem; }
+  </style>
+</head>
+<body>
+  <label for="themeSelect">Theme:</label>
+  <select id="themeSelect">
+    <option value="classic">Classic</option>
+    <option value="bw">Black & White</option>
+    <option value="modern">Modern</option>
+  </select>
+  <div id="content">Loading...</div>
+  <p><a href="player.html">&#x2B05; Back</a></p>
+  <script src="/socket.io/socket.io.js"></script>
+  <script>
+    const sel = document.getElementById('themeSelect');
+    const saved = localStorage.getItem('theme') || 'classic';
+    sel.value = saved;
+    document.getElementById('themeStylesheet').href = `theme-${saved}.css`;
+    sel.onchange = () => {
+      const t = sel.value;
+      localStorage.setItem('theme', t);
+      document.getElementById('themeStylesheet').href = `theme-${t}.css`;
+    };
+    const socket = io();
+    const content = document.getElementById('content');
+    function render(data) {
+      content.innerHTML = '';
+      for (const [chapter, entries] of Object.entries(data)) {
+        const h = document.createElement('h3');
+        h.textContent = chapter.charAt(0).toUpperCase() + chapter.slice(1);
+        content.appendChild(h);
+        const ul = document.createElement('ul');
+        entries.forEach((e) => {
+          const li = document.createElement('li');
+          li.textContent = e;
+          ul.appendChild(li);
+        });
+        content.appendChild(ul);
+      }
+    }
+    socket.emit('getLore');
+    socket.on('loreData', (data) => {
+      render(data);
+    });
+  </script>
+</body>
+</html>

--- a/public/player_client.js
+++ b/public/player_client.js
@@ -91,6 +91,7 @@ window.onload = function () {
         '6. Help\n' +
         '7. Spells\n' +
         '8. Save Character\n' +
+        '9. Lore Book\n' +
         '(Selecting an option opens a new page)'
     );
     phase = 'menu';
@@ -267,6 +268,9 @@ window.onload = function () {
         case '8':
           socket.emit('saveCharacter', currentChar);
           printMessage('Character saved.');
+          break;
+        case '9':
+          window.location.href = 'lore.html';
           break;
         default:
           printMessage('Invalid choice.');


### PR DESCRIPTION
## Summary
- create new `lore.json` to store lore entries
- add new Lore Book page for players
- extend GM menu to add lore entries
- provide server-side lore storage and websocket events
- expose Lore Book option from player menu
- document Lore Book feature in README

## Testing
- `npm test` *(fails: Missing script)*
- `node -e "require('./server.js');"` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685ae04d859c8332b078ba658961f93d