### PR TITLE
Add player icon tokens and movement

### DIFF
--- a/public/gm_menu.js
+++ b/public/gm_menu.js
@@ -77,6 +77,7 @@ function showCharMenu() {
     '1. List characters\n' +
     '2. Delete character\n' +
     '3. Save character\n' +
+    '4. Set icon\n' +
     '0. Return';
   canvas.style.display = 'none';
   palette.style.display = 'none';
@@ -186,6 +187,10 @@ function handleInput(text) {
         display.textContent = 'Enter character JSON:';
         mode = 'savechar';
         break;
+      case '4':
+        display.textContent = 'Enter character name to set icon:';
+        mode = 'iconName';
+        break;
       case '0':
         showMainMenu();
         break;
@@ -246,6 +251,22 @@ function handleInput(text) {
       showMainMenu();
       palette.style.display = 'none';
       mapControls.style.display = 'none';
+    }
+  } else if (mode === 'iconName') {
+    charNameTemp = text;
+    buildPalette();
+    palette.style.display = 'block';
+    display.textContent = 'Select icon then press Enter (0 cancel)';
+    mode = 'iconPick';
+  } else if (mode === 'iconPick') {
+    if (text === '0') {
+      palette.style.display = 'none';
+      showMainMenu();
+    } else {
+      socket.emit('setCharIcon', { name: charNameTemp, icon: selectedTile });
+      palette.style.display = 'none';
+      display.textContent = 'Icon set.';
+      mode = 'help';
     }
   } else if (mode === 'help') {
     if (text === '0') {

--- a/public/map.html
+++ b/public/map.html
@@ -34,36 +34,58 @@
     const canvas = document.getElementById('mapCanvas');
     const ctx = canvas.getContext('2d');
 
-    function drawMap(data) {
-      canvas.width = data[0].length * TILE_SIZE;
-      canvas.height = data.length * TILE_SIZE;
+    let mapData = [];
+    let tokens = {};
+    const name = localStorage.getItem('characterName') || '';
+
+    function render() {
+      if (!mapData.length) return;
+      canvas.width = mapData[0].length * TILE_SIZE;
+      canvas.height = mapData.length * TILE_SIZE;
       ctx.clearRect(0, 0, canvas.width, canvas.height);
-      for (let y = 0; y < data.length; y++) {
-        for (let x = 0; x < data[y].length; x++) {
-          drawTile(ctx, data[y][x], x * TILE_SIZE, y * TILE_SIZE);
+      for (let y = 0; y < mapData.length; y++) {
+        for (let x = 0; x < mapData[y].length; x++) {
+          drawTile(ctx, mapData[y][x], x * TILE_SIZE, y * TILE_SIZE);
         }
       }
       ctx.strokeStyle = '#555';
-      for (let x = 0; x <= data[0].length; x++) {
+      for (let x = 0; x <= mapData[0].length; x++) {
         ctx.beginPath();
         ctx.moveTo(x * TILE_SIZE + 0.5, 0);
         ctx.lineTo(x * TILE_SIZE + 0.5, canvas.height);
         ctx.stroke();
       }
-      for (let y = 0; y <= data.length; y++) {
+      for (let y = 0; y <= mapData.length; y++) {
         ctx.beginPath();
         ctx.moveTo(0, y * TILE_SIZE + 0.5);
         ctx.lineTo(canvas.width, y * TILE_SIZE + 0.5);
         ctx.stroke();
       }
+      Object.values(tokens).forEach(t => {
+        if (tileImages[t.icon]) {
+          drawTile(ctx, t.icon, t.x * TILE_SIZE, t.y * TILE_SIZE);
+        }
+      });
     }
 
     (async () => {
       await loadTileset();
       const socket = io();
+      socket.emit('registerPlayer', name);
       socket.emit('getMap');
+      socket.emit('getPlayerPositions');
       socket.on('mapData', (data) => {
-        drawMap(data);
+        mapData = data;
+        render();
+      });
+      socket.on('playerPositions', (data) => {
+        tokens = data;
+        render();
+      });
+      canvas.addEventListener('click', (ev) => {
+        const x = Math.floor(ev.offsetX / TILE_SIZE);
+        const y = Math.floor(ev.offsetY / TILE_SIZE);
+        socket.emit('movePlayer', { name, x, y });
       });
     })();
   </script>


### PR DESCRIPTION
## Summary
- allow GM to assign icons to characters
- keep track of each player's icon and position on the server
- draw player icons on the map and let players move them

## Testing
- `node --check server.js`
- `node --check public/gm_menu.js`


------
https://chatgpt.com/codex/tasks/task_e_685aebb3197c83329f6a56c83c91d06f