### PR TITLE
Add equipped/stowed sections and revert theme

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -26,8 +26,8 @@
   <p><a href="#" id="toggleTheme">Toggle Dark Mode</a></p>
   <script>
     const themeEl = document.getElementById('themeStylesheet');
-    const savedTheme = localStorage.getItem('theme') || 'theme-classic.css';
-    themeEl.href = savedTheme;
+    themeEl.href = 'theme-classic.css';
+    localStorage.setItem('theme', 'theme-classic.css');
     document.getElementById('toggleTheme').onclick = () => {
       const newTheme =
         themeEl.getAttribute('href') === 'theme-dark.css'

--- a/public/items.html
+++ b/public/items.html
@@ -54,10 +54,16 @@
     }
     socket.on('characterLoaded', (charData) => {
       const enc = encumbrance(charData);
+      const equipped = charData.equipped || [];
+      const stowed = (charData.inventory || []).filter(
+        (it) => !equipped.includes(it)
+      );
       display.textContent =
-        'Items:\n' +
-        (charData.inventory || []).join('\n') +
-        `\nGold: ${charData.gold || 0}\nENC:${enc.slots} MV:${enc.mv}`;
+        'Equipped:\n' +
+        (equipped.join('\n') || '(none)') +
+        '\n\nStowed:\n' +
+        (stowed.join('\n') || '(none)') +
+        `\n\nGold: ${charData.gold || 0}\nENC:${enc.slots} MV:${enc.mv}`;
     });
   </script>
 </body>

--- a/public/player_client.js
+++ b/public/player_client.js
@@ -159,8 +159,13 @@ window.onload = function () {
 
   function showItems() {
     const enc = encumbrance(currentChar);
+    const equipped = currentChar.equipped || [];
+    const stowed = (currentChar.inventory || []).filter(
+      (it) => !equipped.includes(it)
+    );
     printMessage(
-      'Items: ' + (currentChar.inventory || []).join(', ') +
+      'Equipped: ' + equipped.join(', ') +
+      '\nStowed: ' + stowed.join(', ') +
       `\nGold: ${currentChar.gold || 0}\nENC:${enc.slots} MV:${enc.mv}`
     );
     showMenu();
@@ -198,7 +203,7 @@ window.onload = function () {
       socket.emit('loadCharacter', text);
       phase = 'loading';
     } else if (phase === 'newName') {
-      currentChar = { name: text, inventory: [] };
+      currentChar = { name: text, inventory: [], equipped: [] };
       printMessage(`Hello ${text}! Choose a class:`);
       classes.forEach((c, i) => printMessage(`${i + 1}. ${c}`));
       phase = 'chooseClass';
@@ -343,6 +348,7 @@ window.onload = function () {
 
   socket.on('characterLoaded', (charData) => {
     currentChar = charData;
+    currentChar.equipped = currentChar.equipped || [];
     printMessage(`Welcome back, ${charData.name}!`);
     localStorage.setItem('characterName', charData.name);
     socket.emit('registerPlayer', charData.name);


### PR DESCRIPTION
## Summary
- divide item display into Equipped and Stowed sections
- track `equipped` items on characters
- remove equipped items when consuming inventory
- reset to classic theme when opening index page

## Testing
- `node --check server.js`
- `node --check public/player_client.js`
- `node --check public/gm_menu.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685aef7c7af483329ab61cc76cb9e904