### PR TITLE
Add OSE class info pages and autosave defaults

### DIFF
--- a/public/character.html
+++ b/public/character.html
@@ -106,7 +106,7 @@
       const s = charData.stats || {};
       display.innerHTML =
         `<strong>${charData.name}</strong><br>` +
-        `Class: ${charData.class} ${charData.alignment} Level ${charData.level}<br>` +
+        `Class: <a href="classinfo.html?c=${encodeURIComponent(charData.class)}" target="_blank">${charData.class}</a> ${charData.alignment} Level ${charData.level}<br>` +
         `Career: ${charData.career || ''}<br>` +
         `STR:${s.STR} DEX:${s.DEX} CON:${s.CON} INT:${s.INT} WIS:${s.WIS} CHA:${s.CHA}<br>` +
         `HP:<input id="hpInput" type="number" value="${charData.hp}" style="width:60px"> ` +

--- a/public/classinfo.html
+++ b/public/classinfo.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Class Info</title>
+  <link id="themeStylesheet" rel="stylesheet" href="theme-classic.css" />
+  <style>
+    body {
+      font-family: monospace;
+      padding: 1rem;
+      margin: 0 auto;
+      max-width: 600px;
+      font-size: 18px;
+      line-height: 1.4;
+      background: var(--bg);
+      color: var(--fg);
+    }
+    a { color: var(--link); }
+  </style>
+</head>
+<body>
+  <script>
+    const theme = localStorage.getItem('theme') || 'theme-classic.css';
+    document.getElementById('themeStylesheet').href = theme;
+  </script>
+  <pre id="infoDisplay">Loading...</pre>
+  <p><a href="player.html">&#x2B05; Back</a></p>
+  <script>
+    const params = new URLSearchParams(window.location.search);
+    const cls = params.get('c') || '';
+    fetch(`classinfo/${cls}.txt`)
+      .then(r => r.ok ? r.text() : 'Class not found.')
+      .then(t => { document.getElementById('infoDisplay').textContent = t; });
+  </script>
+</body>
+</html>

--- a/public/classinfo/Assassin.txt
+++ b/public/classinfo/Assassin.txt
@@ -1,0 +1,6 @@
+Assassin
+Prime Requisite: STR and DEX
+Hit Dice: 1d4 per level to 10th
+Armor: Leather, no shield
+Weapons: Any
+Assassins are killers for hire skilled in disguise and poison. They can backstab like thieves.

--- a/public/classinfo/Barbarian.txt
+++ b/public/classinfo/Barbarian.txt
@@ -1,0 +1,6 @@
+Barbarian
+Prime Requisite: STR and CON
+Hit Dice: 1d8 per level to 9th
+Armor: Chain mail or lighter, shield allowed
+Weapons: Any
+Barbarians are fierce warriors from the wilds with exceptional toughness and survival skills.

--- a/public/classinfo/Bard.txt
+++ b/public/classinfo/Bard.txt
@@ -1,0 +1,6 @@
+Bard
+Prime Requisite: DEX and CHA
+Hit Dice: 1d4 per level to 10th
+Armor: Chain mail or lighter, shield allowed
+Weapons: Any
+Bards are wandering performers and lore keepers. Their music can inspire allies and confuse foes.

--- a/public/classinfo/Cleric.txt
+++ b/public/classinfo/Cleric.txt
@@ -1,0 +1,6 @@
+Cleric
+Prime Requisite: WIS
+Hit Dice: 1d6 per level to 9th
+Armor: Any, shield allowed
+Weapons: Blunt only
+Clerics are holy warriors who wield divine magic and fight undead with special power.

--- a/public/classinfo/Druid.txt
+++ b/public/classinfo/Druid.txt
@@ -1,0 +1,6 @@
+Druid
+Prime Requisite: WIS
+Hit Dice: 1d6 per level to 14th
+Armor: Leather, shield allowed
+Weapons: Club, dagger, spear and staff
+Druids wield divine magic rooted in nature and can change into animal form at higher levels.

--- a/public/classinfo/Fighter.txt
+++ b/public/classinfo/Fighter.txt
@@ -1,0 +1,6 @@
+Fighter
+Prime Requisite: STR
+Hit Dice: 1d8 per level to 9th
+Armor: Any, shield allowed
+Weapons: Any
+Fighters are professional warriors. They fight better than other classes and may use any equipment.

--- a/public/classinfo/Illusionist.txt
+++ b/public/classinfo/Illusionist.txt
@@ -1,0 +1,6 @@
+Illusionist
+Prime Requisite: INT
+Hit Dice: 1d4 per level to 9th
+Armor: None
+Weapons: Dagger and staff
+Illusionists are magic-users specialising in deceptive spells and phantasms.

--- a/public/classinfo/Knight.txt
+++ b/public/classinfo/Knight.txt
@@ -1,0 +1,6 @@
+Knight
+Prime Requisite: STR
+Hit Dice: 1d8 per level to 9th
+Armor: Any, shield allowed
+Weapons: Any
+Knights are heavily armored champions sworn to a liege and bound by a code of honor.

--- a/public/classinfo/Magic-User.txt
+++ b/public/classinfo/Magic-User.txt
@@ -1,0 +1,6 @@
+Magic-User
+Prime Requisite: INT
+Hit Dice: 1d4 per level to 9th
+Armor: None
+Weapons: Dagger and staff
+Magic-Users study arcane spells. They can use only simple weapons but have powerful magic.

--- a/public/classinfo/Paladin.txt
+++ b/public/classinfo/Paladin.txt
@@ -1,0 +1,6 @@
+Paladin
+Prime Requisite: STR and CHA
+Hit Dice: 1d8 per level to 9th
+Armor: Any, shield allowed
+Weapons: Any
+Paladins are holy warriors dedicated to righteousness. They can lay on hands to heal and repel evil.

--- a/public/classinfo/Ranger.txt
+++ b/public/classinfo/Ranger.txt
@@ -1,0 +1,6 @@
+Ranger
+Prime Requisite: STR and WIS
+Hit Dice: 1d8 per level to 9th
+Armor: Any, shield allowed
+Weapons: Any
+Rangers are wilderness trackers and hunters. They are skilled with bows and can follow trails with ease.

--- a/public/classinfo/Thief.txt
+++ b/public/classinfo/Thief.txt
@@ -1,0 +1,6 @@
+Thief
+Prime Requisite: DEX
+Hit Dice: 1d4 per level to 10th
+Armor: Leather, no shield
+Weapons: Any light
+Thieves excel at stealth, locks, and traps. They can backstab foes when attacking from surprise.

--- a/public/player_client.js
+++ b/public/player_client.js
@@ -328,8 +328,19 @@ window.onload = function () {
       currentChar = { name: text, inventory: [], equipped: [] };
       printMessage(`Hello ${text}! Choose a class:`);
       classes.forEach((c, i) => printMessage(`${i + 1}. ${c}`));
+      printMessage('Type the number to select or number followed by A for info.');
       phase = 'chooseClass';
     } else if (phase === 'chooseClass') {
+      const infoMatch = text.match(/^(\d+)a$/i);
+      if (infoMatch) {
+        const i = parseInt(infoMatch[1]) - 1;
+        if (classes[i]) {
+          window.open(`classinfo.html?c=${encodeURIComponent(classes[i])}`, '_blank');
+        } else {
+          printMessage('Invalid choice.');
+        }
+        return;
+      }
       const idx = parseInt(text) - 1;
       if (classes[idx]) {
         currentChar.class = classes[idx];

--- a/server.js
+++ b/server.js
@@ -38,6 +38,14 @@ let currentMap = null;
 let savedCharacters = {};
 let lore = { characters: [], deaths: [], events: [], locations: [] };
 let sharedText = "Welcome to the campaign.";
+
+// Ensure base data files exist
+if (!fs.existsSync(CHAR_FILE)) fs.writeFileSync(CHAR_FILE, '{}');
+if (!fs.existsSync(LOG_FILE)) fs.writeFileSync(LOG_FILE, '');
+if (!fs.existsSync(MAP_FILE))
+  fs.writeFileSync(MAP_FILE, JSON.stringify({ maps: {}, sharedMap: null }, null, 2));
+if (!fs.existsSync(LORE_FILE))
+  fs.writeFileSync(LORE_FILE, JSON.stringify(lore, null, 2));
 // Track which player sockets map to which names and ready status
 const playerNames = {};
 const readyState = {};


### PR DESCRIPTION
## Summary
- add `classinfo.html` and text entries for each class
- display a link to class info on character sheet
- allow `number + A` during character creation to view class info
- create data files on startup if missing

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685af424dcec83329f8c166ece0bda39