### PR TITLE
Add DM sheet editing and drunk status

### DIFF
--- a/public/character.html
+++ b/public/character.html
@@ -38,7 +38,9 @@
 
     const display = document.getElementById('charDisplay');
     const socket = io();
-    const name = localStorage.getItem('characterName');
+    const params = new URLSearchParams(window.location.search);
+    const name = params.get('n') || localStorage.getItem('characterName');
+    const dmMode = params.has('dm');
     if (name) {
       socket.emit('loadCharacter', name);
     } else {
@@ -104,6 +106,14 @@
     socket.on('characterLoaded', (charData) => {
       currentChar = charData;
       const s = charData.stats || {};
+      const statusList = charData.status || [];
+      const statusHtml = statusList.length
+        ? statusList
+            .map((s) =>
+              dmMode ? `${s} <button data-s="${s}" class="rm">x</button>` : s
+            )
+            .join(', ')
+        : '(none)';
       display.innerHTML =
         `<strong>${charData.name}</strong><br>` +
         `Class: <a href="classinfo.html?c=${encodeURIComponent(charData.class)}" target="_blank">${charData.class}</a> ${charData.alignment} Level ${charData.level}<br>` +
@@ -112,6 +122,7 @@
         `HP:<input id="hpInput" type="number" value="${charData.hp}" style="width:60px"> ` +
         `AC:${charData.ac} ` +
         `XP:<input id="xpInput" type="number" value="${charData.xp}" style="width:80px">/${charData.nextLevelXP}<br>` +
+        `Active Status: ${statusHtml}<br>` +
         `<button id="saveBtn">Save</button>`;
 
       document.getElementById('saveBtn').onclick = () => {
@@ -121,6 +132,15 @@
         socket.emit('saveCharacter', currentChar);
         alert('Character saved');
       };
+
+      if (dmMode) {
+        document.querySelectorAll('.rm').forEach((btn) => {
+          btn.onclick = () => {
+            const stat = btn.getAttribute('data-s');
+            socket.emit('removeStatus', { name: charData.name, status: stat });
+          };
+        });
+      }
     });
   </script>
 </body>

--- a/public/gm_menu.js
+++ b/public/gm_menu.js
@@ -80,6 +80,9 @@ function showCharMenu() {
     '2. Delete character\n' +
     '3. Save character\n' +
     '4. Set icon\n' +
+    '5. View sheet\n' +
+    '6. Give item/gold\n' +
+    '7. Remove status\n' +
     '0. Return';
   canvas.style.display = 'none';
   palette.style.display = 'none';
@@ -210,6 +213,18 @@ function handleInput(text) {
         display.textContent = 'Enter character name to set icon:';
         mode = 'iconName';
         break;
+      case '5':
+        display.textContent = 'Enter character name to view:';
+        mode = 'viewSheet';
+        break;
+      case '6':
+        display.textContent = 'Enter character name to give item/gold:';
+        mode = 'giveItemName';
+        break;
+      case '7':
+        display.textContent = 'Enter character name to remove status:';
+        mode = 'removeStatusName';
+        break;
       case '0':
         showMainMenu();
         break;
@@ -287,6 +302,32 @@ function handleInput(text) {
       display.textContent = 'Icon set.';
       mode = 'help';
     }
+  } else if (mode === 'viewSheet') {
+    window.open(`character.html?n=${encodeURIComponent(text)}&dm=1`, '_blank');
+    showMainMenu();
+  } else if (mode === 'giveItemName') {
+    charNameTemp = text;
+    display.textContent = 'Enter item name or "gp N":';
+    mode = 'giveItemValue';
+  } else if (mode === 'giveItemValue') {
+    const m = text.match(/^gp\s+(\d+)/i);
+    if (m) {
+      socket.emit('giveItem', { name: charNameTemp, gp: parseInt(m[1], 10) });
+    } else {
+      socket.emit('giveItem', { name: charNameTemp, item: text });
+    }
+    charNameTemp = '';
+    display.textContent = 'Given.';
+    mode = 'help';
+  } else if (mode === 'removeStatusName') {
+    charNameTemp = text;
+    display.textContent = 'Enter status to remove:';
+    mode = 'removeStatusValue';
+  } else if (mode === 'removeStatusValue') {
+    socket.emit('removeStatus', { name: charNameTemp, status: text });
+    charNameTemp = '';
+    display.textContent = 'Status removed.';
+    mode = 'help';
   } else if (mode === 'help') {
     if (text === '0') {
       showMainMenu();

--- a/public/player_client.js
+++ b/public/player_client.js
@@ -162,6 +162,7 @@ window.onload = function () {
     { name: 'Oil Flask', cost: 2 },
     { name: 'Backpack', cost: 5 },
     { name: 'Waterskin', cost: 1 },
+    { name: 'Beer', cost: 1 },
     { name: 'Bedroll', cost: 5 },
     { name: 'Grappling Hook', cost: 25 },
     { name: 'Hammer & Spikes', cost: 3 },
@@ -246,6 +247,9 @@ window.onload = function () {
     );
     printMessage(
       `Level:${currentChar.level} HP:${currentChar.hp} AC:${currentChar.ac} XP:${currentChar.xp}/${currentChar.nextLevelXP}`
+    );
+    printMessage(
+      `Active Status: ${(currentChar.status || []).join(', ') || '(none)'}`
     );
     showMenu();
   }
@@ -461,6 +465,7 @@ window.onload = function () {
   socket.on('characterLoaded', (charData) => {
     currentChar = charData;
     currentChar.equipped = currentChar.equipped || [];
+    currentChar.status = currentChar.status || [];
     printMessage(`Welcome back, ${charData.name}!`);
     localStorage.setItem('characterName', charData.name);
     socket.emit('registerPlayer', charData.name);


### PR DESCRIPTION
## Summary
- allow DM to open any character sheet via query parameters
- show active status on character sheet and allow DM to clear them
- extend GM menu with options to view sheets, grant items or gold, and remove status
- add `beer` to shop and implement drunk mechanics
- scramble drunk player's chat messages

## Testing
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685af784fd30833292523d1e8deb5fbd