### PR TITLE
Expanded character creation and calendar

### DIFF
--- a/public/classinfo.html
+++ b/public/classinfo.html
@@ -10,13 +10,14 @@
       font-family: monospace;
       padding: 1rem;
       margin: 0 auto;
-      max-width: 600px;
-      font-size: 18px;
+      max-width: 95vw;
+      font-size: clamp(14px, 4vw, 18px);
       line-height: 1.4;
       background: var(--bg);
       color: var(--fg);
     }
     a { color: var(--link); }
+    pre { white-space: pre-wrap; }
   </style>
 </head>
 <body>

--- a/public/gm_menu.js
+++ b/public/gm_menu.js
@@ -66,7 +66,8 @@ function showMainMenu() {
     '7. Story dialogue\n' +
     '8. Help\n' +
     '9. Add Lore\n' +
-    '10. Edit Data';
+    '10. Edit Data\n' +
+    '11. Calendar';
   canvas.style.display = 'none';
   palette.style.display = 'none';
   mapControls.style.display = 'none';
@@ -112,6 +113,14 @@ function showDataMenu() {
   palette.style.display = 'none';
   mapControls.style.display = 'none';
   mode = 'dataMenu';
+}
+
+function showCalMenu(dayStr) {
+  display.textContent = `Calendar\nToday: ${dayStr}\n1. Advance day\n0. Return`;
+  canvas.style.display = 'none';
+  palette.style.display = 'none';
+  mapControls.style.display = 'none';
+  mode = 'calMenu';
 }
 
 function drawMap() {
@@ -189,6 +198,10 @@ function handleInput(text) {
         break;
       case '10':
         showDataMenu();
+        break;
+      case '11':
+        socket.emit('getDay');
+        mode = 'calwait';
         break;
       default:
         showMainMenu();
@@ -386,6 +399,14 @@ function handleInput(text) {
     socket.emit('editLog', text);
     display.textContent = 'Log updated.';
     mode = 'help';
+  } else if (mode === 'calMenu') {
+    if (text === '1') {
+      socket.emit('advanceDay');
+    }
+    if (text === '0' || text === '1') {
+      socket.emit('getDay');
+      mode = 'calwait';
+    }
   } else if (mode === 'loadmap') {
     socket.emit('loadMap', text);
     mapName = text;
@@ -440,6 +461,12 @@ socket.on('readyList', (list) => {
   readyDisplay.textContent = Object.entries(list)
     .map(([n, r]) => `${r ? '[READY]' : '[    ]'} ${n}`)
     .join('\n');
+});
+
+socket.on('currentDay', (d) => {
+  if (mode === 'calwait') {
+    showCalMenu(d);
+  }
 });
 
 canvas.addEventListener('click', (ev) => {

--- a/public/journal.html
+++ b/public/journal.html
@@ -34,13 +34,19 @@
     const theme = localStorage.getItem('theme') || 'theme-classic.css';
     document.getElementById('themeStylesheet').href = theme;
   </script>
+  <div id="day"></div>
   <pre id="journal">Loading...</pre>
+  <textarea id="entry" rows="3" style="width:100%;"></textarea>
+  <button id="saveBtn">Save Entry</button>
   <p><a href="player.html">&#x2B05; Back</a></p>
 
   <script src="/socket.io/socket.io.js"></script>
   <script>
     const display = document.getElementById('journal');
+    const entry = document.getElementById('entry');
+    const dayEl = document.getElementById('day');
     const socket = io();
+    const name = localStorage.getItem('characterName') || '';
     function colorize(text) {
       if (text.startsWith('[CHAR]')) return '<span class="gmchar">' + text + '</span>';
       if (text.startsWith('[EVENT]')) return '<span class="gmevent">' + text + '</span>';
@@ -53,13 +59,21 @@
         .replace(/!([\w ]+)/g, '<span class="spell">!$1</span>')
         .replace(/%([\w ]+)/g, '<span class="monster">%$1</span>');
     }
-    socket.emit('getCampaignLog');
-    socket.on('campaignLog', (log) => {
-      display.innerHTML = log.map(colorize).join('<br>');
+    socket.emit('getJournal', name);
+    socket.emit('getDay');
+    socket.on('journalData', (text) => {
+      display.textContent = text;
     });
-    socket.on('logUpdate', (entry) => {
-      display.innerHTML += '<br>' + colorize(entry);
+    socket.on('journalSaved', () => {
+      socket.emit('getJournal', name);
+      entry.value = '';
     });
+    socket.on('currentDay', (d) => { dayEl.textContent = 'Day: ' + d; });
+    document.getElementById('saveBtn').onclick = () => {
+      if (entry.value.trim()) {
+        socket.emit('addJournalEntry', { name, text: entry.value.trim() });
+      }
+    };
   </script>
 </body>
 </html>

--- a/public/player_client.js
+++ b/public/player_client.js
@@ -7,6 +7,8 @@ window.onload = function () {
 
   let phase = 'enterName';
   let currentChar = null;
+  let availableClasses = [];
+  let currentDayStr = '';
 
   const classes = [
     'Fighter',
@@ -153,34 +155,84 @@ window.onload = function () {
     Paladin: 8,
     Ranger: 8
   };
-  const shopItems = [
-    // Adventuring gear
-    { name: 'Rations (1 day)', cost: 5 },
-    { name: 'Torch', cost: 1 },
-    { name: 'Rope (50ft)', cost: 10 },
-    { name: 'Lantern', cost: 10 },
-    { name: 'Oil Flask', cost: 2 },
+  const classReqs = {
+    Fighter: {},
+    Cleric: { WIS: 9 },
+    'Magic-User': { INT: 9 },
+    Thief: { DEX: 9 },
+    Assassin: { STR: 9, DEX: 9 },
+    Barbarian: { STR: 9, CON: 9 },
+    Bard: { DEX: 9, CHA: 9 },
+    Druid: { WIS: 9 },
+    Illusionist: { INT: 9 },
+    Knight: { STR: 9, CHA: 9 },
+    Paladin: { STR: 9, CHA: 9 },
+    Ranger: { STR: 9, WIS: 9, CON: 9 }
+  };
+
+  const weaponAllowed = {
+    'Magic-User': ['Dagger', 'Staff'],
+    Cleric: ['Mace', 'War Hammer', 'Club', 'Staff'],
+    Thief: ['Dagger', 'Short Sword', 'Long Sword', 'Sling', 'Bow', 'Crossbow', 'Club', 'Hand Axe'],
+    Assassin: ['Dagger', 'Short Sword', 'Long Sword', 'Sling', 'Bow', 'Crossbow', 'Club', 'Hand Axe'],
+    Bard: ['Dagger', 'Short Sword', 'Long Sword', 'Sling', 'Bow', 'Crossbow', 'Club'],
+    Druid: ['Club', 'Staff', 'Dagger', 'Spear'],
+    Illusionist: ['Dagger', 'Staff']
+  };
+
+  const armorAllowed = {
+    'Magic-User': [],
+    Thief: ['Leather Armor'],
+    Assassin: ['Leather Armor'],
+    Bard: ['Leather Armor', 'Chain Mail'],
+    Druid: ['Leather Armor', 'Shield'],
+    Illusionist: [],
+    Cleric: ['Leather Armor', 'Chain Mail', 'Plate Mail', 'Shield']
+  };
+
+  const gearItems = [
     { name: 'Backpack', cost: 5 },
-    { name: 'Waterskin', cost: 1 },
     { name: 'Bedroll', cost: 5 },
-    { name: 'Grappling Hook', cost: 25 },
-    { name: 'Hammer & Spikes', cost: 3 },
-    { name: 'Mirror (small)', cost: 5 },
+    { name: 'Candle', cost: 1 },
+    { name: 'Chain (10ft)', cost: 30 },
+    { name: 'Chalk (1 piece)', cost: 1 },
+    { name: 'Crowbar', cost: 10 },
+    { name: 'Flask of oil', cost: 2 },
     { name: 'Flint & Steel', cost: 2 },
-    // Weapons
-    { name: 'Dagger', cost: 10 },
-    { name: 'Short Sword', cost: 30 },
-    { name: 'Long Sword', cost: 50 },
-    { name: 'Mace', cost: 15 },
-    { name: 'Spear', cost: 10 },
-    { name: 'Bow', cost: 40 },
-    { name: 'Arrows (20)', cost: 5 },
-    // Armor
-    { name: 'Shield', cost: 10 },
-    { name: 'Leather Armor', cost: 20 },
-    { name: 'Chain Mail', cost: 40 },
-    { name: 'Plate Mail', cost: 60 },
-    { name: 'Spellbook', cost: 50 }
+    { name: 'Grappling Hook', cost: 25 },
+    { name: 'Hammer', cost: 2 },
+    { name: 'Holy Water', cost: 25 },
+    { name: 'Iron Spikes (12)', cost: 1 },
+    { name: 'Lantern', cost: 10 },
+    { name: 'Mirror (small)', cost: 5 },
+    { name: 'Pole (10ft)', cost: 1 },
+    { name: 'Rations (1 day)', cost: 5 },
+    { name: 'Rope (50ft)', cost: 10 },
+    { name: 'Sack (large)', cost: 1 },
+    { name: 'Torch', cost: 1 },
+    { name: 'Waterskin', cost: 1 }
+  ];
+
+  const weaponArmorItems = [
+    { name: 'Club', cost: 1, type: 'weapon' },
+    { name: 'Dagger', cost: 10, type: 'weapon' },
+    { name: 'Hand Axe', cost: 4, type: 'weapon' },
+    { name: 'Mace', cost: 15, type: 'weapon' },
+    { name: 'Spear', cost: 10, type: 'weapon' },
+    { name: 'Short Sword', cost: 30, type: 'weapon' },
+    { name: 'Long Sword', cost: 50, type: 'weapon' },
+    { name: 'Two-Handed Sword', cost: 75, type: 'weapon' },
+    { name: 'Polearm', cost: 7, type: 'weapon' },
+    { name: 'Bow', cost: 40, type: 'weapon' },
+    { name: 'Crossbow', cost: 30, type: 'weapon' },
+    { name: 'Arrows (20)', cost: 5, type: 'weapon' },
+    { name: 'Quarrels (30)', cost: 10, type: 'weapon' },
+    { name: 'Sling', cost: 2, type: 'weapon' },
+    { name: 'Shield', cost: 10, type: 'armor' },
+    { name: 'Leather Armor', cost: 20, type: 'armor' },
+    { name: 'Chain Mail', cost: 40, type: 'armor' },
+    { name: 'Plate Mail', cost: 60, type: 'armor' },
+    { name: 'Spellbook', cost: 50, type: 'special' }
   ];
   const spells = ['Magic Missile', 'Shield', 'Sleep', 'Light', 'Charm Person'];
 
@@ -208,7 +260,8 @@ window.onload = function () {
 
   function showMenu() {
     printMessage(
-      'Main Menu\n' +
+      `Day: ${currentDayStr}\n` +
+        'Main Menu\n' +
         '1. Character Sheet\n' +
         '2. Items\n' +
         '3. Map\n' +
@@ -297,14 +350,6 @@ window.onload = function () {
     currentChar.inventory.push(...career.items);
     printMessage(`Your career is ${career.name}. You start with: ${career.items.join(', ')}`);
     careerButton.style.display = 'none';
-    currentChar.stats = {
-      STR: rollStat(),
-      DEX: rollStat(),
-      CON: rollStat(),
-      INT: rollStat(),
-      WIS: rollStat(),
-      CHA: rollStat()
-    };
     const hd = hitDie[currentChar.class] || 6;
     currentChar.level = 1;
     currentChar.hp = Math.floor(Math.random() * hd) + 1;
@@ -313,10 +358,9 @@ window.onload = function () {
     currentChar.nextLevelXP = xpTable[currentChar.class][1];
     const roll = () => Math.floor(Math.random() * 6) + 1;
     currentChar.gold = (roll() + roll() + roll()) * 10;
-    printMessage(`Stats rolled: STR ${currentChar.stats.STR}, DEX ${currentChar.stats.DEX}, CON ${currentChar.stats.CON}, INT ${currentChar.stats.INT}, WIS ${currentChar.stats.WIS}, CHA ${currentChar.stats.CHA}`);
     printMessage(`You have ${currentChar.gold}gp to spend.`);
-    showShop();
-    phase = 'shop';
+    showShopMenu();
+    phase = 'shopMenu';
   });
 
   function handleInput(text) {
@@ -324,26 +368,41 @@ window.onload = function () {
     if (phase === 'enterName') {
       socket.emit('loadCharacter', text);
       phase = 'loading';
-    } else if (phase === 'newName') {
+  } else if (phase === 'newName') {
       currentChar = { name: text, inventory: [], equipped: [] };
+      currentChar.stats = {
+        STR: rollStat(),
+        DEX: rollStat(),
+        CON: rollStat(),
+        INT: rollStat(),
+        WIS: rollStat(),
+        CHA: rollStat()
+      };
+      printMessage(
+        `Stats: STR ${currentChar.stats.STR} DEX ${currentChar.stats.DEX} CON ${currentChar.stats.CON} INT ${currentChar.stats.INT} WIS ${currentChar.stats.WIS} CHA ${currentChar.stats.CHA}`
+      );
+      availableClasses = classes.filter((c) => {
+        const req = classReqs[c] || {};
+        return Object.entries(req).every(([k, v]) => currentChar.stats[k] >= v);
+      });
       printMessage(`Hello ${text}! Choose a class:`);
-      classes.forEach((c, i) => printMessage(`${i + 1}. ${c}`));
+      availableClasses.forEach((c, i) => printMessage(`${i + 1}. ${c}`));
       printMessage('Type the number to select or number followed by A for info.');
       phase = 'chooseClass';
     } else if (phase === 'chooseClass') {
       const infoMatch = text.match(/^(\d+)a$/i);
       if (infoMatch) {
         const i = parseInt(infoMatch[1]) - 1;
-        if (classes[i]) {
-          window.open(`classinfo.html?c=${encodeURIComponent(classes[i])}`, '_blank');
+        if (availableClasses[i]) {
+          window.open(`classinfo.html?c=${encodeURIComponent(availableClasses[i])}`, '_blank');
         } else {
           printMessage('Invalid choice.');
         }
         return;
       }
       const idx = parseInt(text) - 1;
-      if (classes[idx]) {
-        currentChar.class = classes[idx];
+      if (availableClasses[idx]) {
+        currentChar.class = availableClasses[idx];
         printMessage('Choose an alignment:');
         alignments.forEach((a, i) => printMessage(`${i + 1}. ${a}`));
         phase = 'chooseAlignment';
@@ -360,8 +419,14 @@ window.onload = function () {
       } else {
         printMessage('Invalid choice.');
       }
-    } else if (phase === 'shop') {
-      if (text === '0') {
+    } else if (phase === 'shopMenu') {
+      if (text === '1') {
+        showGear();
+        phase = 'shopGear';
+      } else if (text === '2') {
+        showWeapons();
+        phase = 'shopWeapons';
+      } else if (text === '0') {
         if (currentChar.class === 'Magic-User') {
           printMessage('Choose a starting spell:');
           spells.forEach((s, i) => printMessage(`${i + 1}. ${s}`));
@@ -369,10 +434,36 @@ window.onload = function () {
         } else {
           finalizeCharacter();
         }
+      } else {
+        printMessage('Invalid choice.');
+      }
+    } else if (phase === 'shopGear') {
+      if (text === '0') {
+        showShopMenu();
+        phase = 'shopMenu';
         return;
       }
       const idx = parseInt(text) - 1;
-      const item = shopItems[idx];
+      const item = gearItems[idx];
+      if (item) {
+        if (currentChar.gold >= item.cost) {
+          currentChar.gold -= item.cost;
+          currentChar.inventory.push(item.name);
+          printMessage(`Purchased ${item.name}. Gold left: ${currentChar.gold}`);
+        } else {
+          printMessage('Not enough gold.');
+        }
+      } else {
+        printMessage('Invalid item.');
+      }
+    } else if (phase === 'shopWeapons') {
+      if (text === '0') {
+        showShopMenu();
+        phase = 'shopMenu';
+        return;
+      }
+      const idx = parseInt(text) - 1;
+      const item = weaponListCurrent[idx];
       if (item) {
         if (currentChar.gold >= item.cost) {
           currentChar.gold -= item.cost;
@@ -447,9 +538,32 @@ window.onload = function () {
     }
   }
 
-  function showShop() {
-    printMessage('Shop - enter item number to buy, or 0 to finish:');
-    shopItems.forEach((it, i) => printMessage(`${i + 1}. ${it.name} (${it.cost}gp)`));
+  let weaponListCurrent = [];
+
+  function canUse(item) {
+    if (item.type === 'weapon') {
+      const allow = weaponAllowed[currentChar.class];
+      return !allow || allow === 'ANY' || allow.includes(item.name);
+    } else if (item.type === 'armor') {
+      const allow = armorAllowed[currentChar.class];
+      return !allow || allow === 'ANY' || allow.includes(item.name);
+    }
+    return true;
+  }
+
+  function showShopMenu() {
+    printMessage('Shop\n1. Adventuring Gear\n2. Weapons & Armor\n0. Finish');
+  }
+
+  function showGear() {
+    printMessage('Adventuring Gear - 0 to return');
+    gearItems.forEach((it, i) => printMessage(`${i + 1}. ${it.name} (${it.cost}gp)`));
+  }
+
+  function showWeapons() {
+    weaponListCurrent = weaponArmorItems.filter(canUse);
+    printMessage('Weapons & Armor - 0 to return');
+    weaponListCurrent.forEach((it, i) => printMessage(`${i + 1}. ${it.name} (${it.cost}gp)`));
   }
 
   function finalizeCharacter() {
@@ -475,6 +589,10 @@ window.onload = function () {
 
   socket.on('logUpdate', (entry) => {
     printMessage(entry);
+  });
+
+  socket.on('currentDay', (d) => {
+    currentDayStr = d;
   });
 
   socket.on('mapData', (data) => {

--- a/server.js
+++ b/server.js
@@ -25,6 +25,13 @@ const LORE_DIR = path.join(DATA_DIR, 'lore');
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
 });
 
+// Journals and calendar tracking
+const JOURNAL_DIR = path.join(DATA_DIR, 'journals');
+const DAY_FILE = path.join(DATA_DIR, 'day.json');
+[JOURNAL_DIR].forEach((dir) => {
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+});
+
 const CHAR_FILE = path.join(CHAR_DIR, 'player_data.json');
 const LOG_FILE = path.join(CHAT_DIR, 'campaign_log.txt');
 const MAP_FILE = path.join(MAP_DIR, 'map_data.json');
@@ -38,6 +45,35 @@ let currentMap = null;
 let savedCharacters = {};
 let lore = { characters: [], deaths: [], events: [], locations: [] };
 let sharedText = "Welcome to the campaign.";
+
+// Calendar
+const MONTHS = [
+  'early spring',
+  'late spring',
+  'early summer',
+  'later summer',
+  'early fall',
+  'late fall',
+  'early winter',
+  'later winter'
+];
+const MONTH_DAYS = [31, 31, 31, 33, 31, 31, 31, 31];
+let currentDay = { month: 0, day: 1 };
+if (fs.existsSync(DAY_FILE)) {
+  try {
+    currentDay = JSON.parse(fs.readFileSync(DAY_FILE));
+  } catch (e) {}
+}
+
+function saveDay() {
+  fs.writeFileSync(DAY_FILE, JSON.stringify(currentDay));
+}
+
+function formatDay() {
+  const d = currentDay.day;
+  const suffix = d === 1 ? 'st' : d === 2 ? 'nd' : d === 3 ? 'rd' : 'th';
+  return `${d}${suffix} of ${MONTHS[currentDay.month]}`;
+}
 
 // Ensure base data files exist
 if (!fs.existsSync(CHAR_FILE)) fs.writeFileSync(CHAR_FILE, '{}');
@@ -89,6 +125,15 @@ function saveLore() {
   fs.writeFile(LORE_FILE, JSON.stringify(lore, null, 2), () => {});
 }
 
+function advanceDay() {
+  currentDay.day += 1;
+  if (currentDay.day > MONTH_DAYS[currentDay.month]) {
+    currentDay.day = 1;
+    currentDay.month = (currentDay.month + 1) % MONTHS.length;
+  }
+  saveDay();
+}
+
 // Load saved characters from file
 if (fs.existsSync(CHAR_FILE)) {
   try {
@@ -133,6 +178,7 @@ app.get('/', (req, res) => {
 
 io.on("connection", (socket) => {
   console.log("Client connected:", socket.id);
+  socket.emit("currentDay", formatDay());
 
   socket.on("registerPlayer", (name) => {
     playerNames[socket.id] = name;
@@ -407,6 +453,30 @@ io.on("connection", (socket) => {
         locations: lore.locations,
       });
     }
+  });
+
+  socket.on("getJournal", (name) => {
+    const file = path.join(JOURNAL_DIR, `${name}.txt`);
+    let text = "";
+    if (fs.existsSync(file)) {
+      try { text = fs.readFileSync(file, "utf8"); } catch (e) {}
+    }
+    socket.emit("journalData", text);
+  });
+
+  socket.on("addJournalEntry", ({ name, text }) => {
+    const file = path.join(JOURNAL_DIR, `${name}.txt`);
+    fs.appendFile(file, text.trim() + "\n", () => {});
+    socket.emit("journalSaved");
+  });
+
+  socket.on("getDay", () => {
+    socket.emit("currentDay", formatDay());
+  });
+
+  socket.on("advanceDay", () => {
+    advanceDay();
+    io.emit("currentDay", formatDay());
   });
 
   socket.on("getSharedText", () => {


### PR DESCRIPTION
## Summary
- roll stats before class choice and gate classes based on requirements
- add per-character journals and campaign calendar
- resize class info text on small screens
- expand shop into gear and weapons/armor filtered by class
- allow GM to manage campaign calendar

## Testing
- `npm test` *(fails: Missing script)*
- `node --check server.js`
- `node --check public/player_client.js`
- `node --check public/gm_menu.js`


------
https://chatgpt.com/codex/tasks/task_e_685af94ad6748332a092586e4840e4f9