### PR TITLE
Add calendar and shop improvements

### DIFF
--- a/public/classinfo.html
+++ b/public/classinfo.html
@@ -24,7 +24,7 @@
     const theme = localStorage.getItem('theme') || 'theme-classic.css';
     document.getElementById('themeStylesheet').href = theme;
   </script>
-  <pre id="infoDisplay">Loading...</pre>
+  <pre id="infoDisplay" style="white-space: pre-wrap; word-wrap: break-word;">Loading...</pre>
   <p><a href="player.html">&#x2B05; Back</a></p>
   <script>
     const params = new URLSearchParams(window.location.search);

--- a/public/gm_menu.js
+++ b/public/gm_menu.js
@@ -17,6 +17,8 @@ let mapData = [];
 let mapName = '';
 let selectedTile = '';
 
+let currentDateText = '';
+
 let charNameTemp = '';
 
 let tiles = [];
@@ -66,7 +68,8 @@ function showMainMenu() {
     '7. Story dialogue\n' +
     '8. Help\n' +
     '9. Add Lore\n' +
-    '10. Edit Data';
+    '10. Edit Data\n' +
+    '11. Calendar';
   canvas.style.display = 'none';
   palette.style.display = 'none';
   mapControls.style.display = 'none';
@@ -115,6 +118,14 @@ function showDataMenu() {
   palette.style.display = 'none';
   mapControls.style.display = 'none';
   mode = 'dataMenu';
+}
+
+function showCalendarMenu() {
+  display.textContent = `Calendar\nToday: ${currentDateText}\n1. Advance day\n0. Return`;
+  canvas.style.display = 'none';
+  palette.style.display = 'none';
+  mapControls.style.display = 'none';
+  mode = 'calendar';
 }
 
 function drawMap() {
@@ -192,6 +203,10 @@ function handleInput(text) {
         break;
       case '10':
         showDataMenu();
+        break;
+      case '11':
+        socket.emit('getDate');
+        showCalendarMenu();
         break;
       default:
         showMainMenu();
@@ -427,6 +442,13 @@ function handleInput(text) {
     socket.emit('editLog', text);
     display.textContent = 'Log updated.';
     mode = 'help';
+  } else if (mode === 'calendar') {
+    if (text === '1') {
+      socket.emit('advanceDay');
+    }
+    if (text === '0' || text === '1') {
+      showMainMenu();
+    }
   } else if (mode === 'loadmap') {
     socket.emit('loadMap', text);
     mapName = text;
@@ -483,6 +505,11 @@ socket.on('readyList', (list) => {
     .join('\n');
 });
 
+socket.on('currentDate', (d) => {
+  currentDateText = d;
+  if (mode === 'calendar') showCalendarMenu();
+});
+
 canvas.addEventListener('click', (ev) => {
   if (mode !== 'editmap') return;
   const x = Math.floor(ev.offsetX / cellSize);
@@ -525,6 +552,7 @@ fillMapBtn.addEventListener('click', () => {
   await loadTileset();
   tiles = TILES;
   selectedTile = TILES[0];
+  socket.emit('getDate');
   showMainMenu();
   input.focus();
 })();

--- a/public/journal.html
+++ b/public/journal.html
@@ -34,32 +34,28 @@
     const theme = localStorage.getItem('theme') || 'theme-classic.css';
     document.getElementById('themeStylesheet').href = theme;
   </script>
-  <pre id="journal">Loading...</pre>
+  <textarea id="journal" rows="10" style="width:100%">Loading...</textarea>
   <p><a href="player.html">&#x2B05; Back</a></p>
 
   <script src="/socket.io/socket.io.js"></script>
   <script>
-    const display = document.getElementById('journal');
-    const socket = io();
-    function colorize(text) {
-      if (text.startsWith('[CHAR]')) return '<span class="gmchar">' + text + '</span>';
-      if (text.startsWith('[EVENT]')) return '<span class="gmevent">' + text + '</span>';
-      if (text.startsWith('[STORY]')) return '<span class="gmstory">' + text + '</span>';
-      return text
-        .replace(/#([\w ]+)/g, '<span class="item">#$1</span>')
-        .replace(/\$(\d+)/g, '<span class="gold">$$$1</span>')
-        .replace(/@([\w ]+)/g, '<span class="char">@$1</span>')
-        .replace(/&([\w ]+)/g, '<span class="location">&$1</span>')
-        .replace(/!([\w ]+)/g, '<span class="spell">!$1</span>')
-        .replace(/%([\w ]+)/g, '<span class="monster">%$1</span>');
-    }
-    socket.emit('getCampaignLog');
-    socket.on('campaignLog', (log) => {
-      display.innerHTML = log.map(colorize).join('<br>');
-    });
-    socket.on('logUpdate', (entry) => {
-      display.innerHTML += '<br>' + colorize(entry);
-    });
+  const display = document.getElementById('journal');
+  const socket = io();
+  const name = localStorage.getItem('characterName');
+  if (name) {
+    socket.emit('getJournal', name);
+  }
+  let saveTimer;
+  display.addEventListener('input', () => {
+    if (!name) return;
+    clearTimeout(saveTimer);
+    saveTimer = setTimeout(() => {
+      socket.emit('saveJournal', { name, text: display.value });
+    }, 500);
+  });
+  socket.on('journalData', (text) => {
+    display.value = text;
+  });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- support a game calendar with new GM controls
- remove Beer from starting shop and categorize gear vs weapons
- filter shop items by class and roll stats before class selection
- scale class description text and allow players to keep a personal journal
- save journals and calendar data on the server

## Testing
- `node --version`
- `node -c server.js`
- `node -c public/player_client.js`
- `node -c public/gm_menu.js`


------
https://chatgpt.com/codex/tasks/task_e_685b01d6ab3c8332b495409520786b14