### PR TITLE
Allow custom data directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ OSE RPG Full Bundle
 3. Visit [http://localhost:3000/player.html](http://localhost:3000/player.html) in your browser.
 
 All user generated content is written under `data/`.
+The location can be overridden by setting the `OSE_RPG_DATA_DIR`
+environment variable before starting the server. This allows you to keep
+campaign files on a separate disk.
 Files are organised into persistent folders:
 
 - `data/characters` - saved player characters

--- a/server.js
+++ b/server.js
@@ -11,7 +11,11 @@ const io = new Server(server);
 const PORT = process.env.PORT || 3000;
 
 // Persist user generated content under the data directory
-const DATA_DIR = path.join(__dirname, 'data');
+// The location can be overridden by setting the OSE_RPG_DATA_DIR
+// environment variable, allowing saves on a separate disk
+const DATA_DIR = process.env.OSE_RPG_DATA_DIR
+  ? path.resolve(process.env.OSE_RPG_DATA_DIR)
+  : path.join(__dirname, 'data');
 if (!fs.existsSync(DATA_DIR)) {
   fs.mkdirSync(DATA_DIR);
 }


### PR DESCRIPTION
## Summary
- support saving data outside the repo via `OSE_RPG_DATA_DIR`
- document the environment variable in the README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685b580ecde08332a436daee91935f16