### PR TITLE
Add favorite food question to character creation

### DIFF
--- a/public/character.html
+++ b/public/character.html
@@ -120,6 +120,7 @@
         `Career: ${charData.career || ''}<br>` +
         (charData.homeTown && charData.homeTown.name ? `Hometown: ${charData.homeTown.name}<br>` : '') +
         (charData.motivation ? `Motivation: ${charData.motivation}<br>` : '') +
+        (charData.favoriteFood ? `Favorite Food: ${charData.favoriteFood}<br>` : '') +
         `STR:${s.STR} DEX:${s.DEX} CON:${s.CON} INT:${s.INT} WIS:${s.WIS} CHA:${s.CHA}<br>` +
         `HP:<input id="hpInput" type="number" value="${charData.hp}" style="width:60px"> ` +
         `AC:${charData.ac} ` +

--- a/public/player_client.js
+++ b/public/player_client.js
@@ -479,12 +479,15 @@ window.onload = function () {
       const idx = parseInt(text) - 1;
       if (motivations[idx]) {
         currentChar.motivation = motivations[idx];
-        printMessage('Click the Roll Career button to get your career.');
-        careerButton.style.display = 'inline-block';
-        phase = 'chooseCareer';
+        askFavoriteFood();
       } else {
         printMessage('Invalid choice.');
       }
+    } else if (phase === 'favoriteFood') {
+      currentChar.favoriteFood = text;
+      printMessage('Click the Roll Career button to get your career.');
+      careerButton.style.display = 'inline-block';
+      phase = 'chooseCareer';
     } else if (phase === 'shopMenu') {
       if (text === '1') {
         showShop();
@@ -646,6 +649,11 @@ window.onload = function () {
     printMessage('What brings you to The Bloclands?');
     motivations.forEach((m, i) => printMessage(`${i + 1}. ${m}`));
     phase = 'chooseMotivation';
+  }
+
+  function askFavoriteFood() {
+    printMessage('What is your favorite food?');
+    phase = 'favoriteFood';
   }
 
   function canUseItem(it) {


### PR DESCRIPTION
## Summary
- ask players for their favorite food during character creation
- display the favorite food on the character sheet

## Testing
- `node --check public/player_client.js`


------
https://chatgpt.com/codex/tasks/task_e_685b60e5b5408332b3361a09789b980b