### PR TITLE
Add load all data option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Campaign data is automatically exported to the appropriate subfolders whenever i
 The GM Data Menu now includes an **Export all** option and players can select
 **Export Character** from the main menu to write their character file to
 `data/characters`.
+The Data Menu also has a **Load all** option to reload characters, maps, lore
+and chat logs from the save directory, which can be outside the main project by
+setting the `OSE_RPG_DATA_DIR` environment variable.
 
 **GM Map Maker**
 - Choose **Map Menu** from the GM interface.

--- a/public/gm_menu.js
+++ b/public/gm_menu.js
@@ -112,6 +112,7 @@ function showDataMenu() {
     '4. Edit log\n' +
     '5. Save all\n' +
     '6. Export all\n' +
+    '7. Load all\n' +
     '0. Return';
   canvas.style.display = 'none';
   palette.style.display = 'none';
@@ -390,6 +391,11 @@ function handleInput(text) {
       case '6':
         socket.emit('exportAll');
         display.textContent = 'Data exported.';
+        mode = 'help';
+        break;
+      case '7':
+        socket.emit('loadAllData');
+        display.textContent = 'Data loaded.';
         mode = 'help';
         break;
       case '0':


### PR DESCRIPTION
## Summary
- factor file loading logic into a `loadAll` function
- call `loadAll` on startup and expose a new `loadAllData` socket event
- add a `Load all` option in the GM data menu
- document the new option in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685b63cdf5ec8332ae243cc8ddf60c3d