### PR TITLE
Reorder character creation

### DIFF
--- a/public/character.html
+++ b/public/character.html
@@ -143,6 +143,7 @@
         (charData.homeTown && charData.homeTown.name ? `Hometown: ${charData.homeTown.name}<br>` : '') +
         (charData.motivation ? `Motivation: ${charData.motivation}<br>` : '') +
         (charData.favoriteFood ? `Favorite Food: ${charData.favoriteFood}<br>` : '') +
+        (charData.languages ? `Languages: ${charData.languages.join(', ')}<br>` : '') +
         `STR:${s.STR} DEX:${s.DEX} CON:${s.CON} INT:${s.INT} WIS:${s.WIS} CHA:${s.CHA}<br>` +
         `HP:<input id="hpInput" type="number" value="${charData.hp}" style="width:60px"> ` +
         `AC:${charData.ac} ` +


### PR DESCRIPTION
## Summary
- update player creation flow to start with settlement generator
- roll careers before stats and race
- remove death & food prompts, include languages and class title
- display languages on the character sheet

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c92dd1b1883328d59539134e69d7d