### PR TITLE
Make theme black and white and add region map link

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,22 +4,17 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>OSE RPG Entry</title>
-  <link id="themeStylesheet" rel="stylesheet" href="public/theme-classic.css" />
+  <link rel="stylesheet" href="public/theme-bw.css" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Tiny5&family=Micro+5+Charted&family=Jacquard+12&display=swap">
   <style>
-    body { font-family: 'Tiny5', monospace; padding: 2rem; max-width: 600px; margin: 0 auto; font-size: 18px; line-height: 1.4; background: var(--bg); color: var(--fg); }
+    body { font-family: 'Tiny5', monospace; padding: 1rem; max-width: 100%; margin: 0 auto; font-size: 16px; line-height: 1.4; background: var(--bg); color: var(--fg); }
     a { color: var(--link); display: block; margin: 1rem 0; }
   </style>
 </head>
 <body>
   <h1 style="font-family:'Jacquard 12',serif;">The Blocland Lands</h1>
-  <script>
-    document.getElementById('themeStylesheet').href = 'public/theme-classic.css';
-  </script>
   <p><a href="/player.html">▶ Join as Player</a></p>
   <p><a href="/dm.html">🎲 Launch GM Tools</a></p>
-  <script>
-    // theme fixed to classic
-  </script>
+  <p><a href="/dm.html#region">🗺️ Region Map Maker</a></p>
 </body>
 </html>

--- a/public/character.html
+++ b/public/character.html
@@ -4,15 +4,15 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Character Sheet</title>
-  <link id="themeStylesheet" rel="stylesheet" href="theme-classic.css" />
+  <link rel="stylesheet" href="theme-bw.css" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Tiny5&family=Jacquard+12&family=Jacquarda+Bastarda+9&family=Jacquard+24&display=swap">
   <style>
     body {
       font-family: 'Tiny5', monospace;
       padding: 1rem;
       margin: 0 auto;
-      max-width: 600px;
-      font-size: 18px;
+      max-width: 100%;
+      font-size: 16px;
       line-height: 1.4;
       background: var(--bg);
       color: var(--fg);
@@ -27,10 +27,6 @@
   </style>
 </head>
 <body>
-  <script>
-    const theme = localStorage.getItem('theme') || 'theme-classic.css';
-    document.getElementById('themeStylesheet').href = theme;
-  </script>
   <div id="charDisplay">Loading...</div>
   <div id="charIcon" style="font-size:30px;margin-top:0.5rem;"></div>
   <p><a href="player.html">&#x2B05; Back</a></p>

--- a/public/chat.html
+++ b/public/chat.html
@@ -4,15 +4,15 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Chat</title>
-  <link id="themeStylesheet" rel="stylesheet" href="theme-classic.css" />
+  <link rel="stylesheet" href="theme-bw.css" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Tiny5&family=Jacquard+12&family=Jacquarda+Bastarda+9&family=Jacquard+24&display=swap">
   <style>
     body {
       font-family: 'Tiny5', monospace;
       padding: 1rem;
       margin: 0 auto;
-      max-width: 600px;
-      font-size: 18px;
+      max-width: 100%;
+      font-size: 16px;
       line-height: 1.4;
       background: var(--bg);
       color: var(--fg);
@@ -30,14 +30,10 @@
     .gmchar { color: lightgreen; }
     .gmevent { color: orange; }
     .gmstory { color: plum; }
-    input { width: 100%; font-size: 18px; margin-top: 0.5rem; background: var(--accent-bg); color: var(--accent-fg); border: 1px solid var(--border); }
+    input { width: 100%; font-size: 16px; margin-top: 0.5rem; background: var(--accent-bg); color: var(--accent-fg); border: 1px solid var(--border); font-family: 'Tiny5', monospace; }
   </style>
 </head>
 <body>
-  <script>
-    const theme = localStorage.getItem('theme') || 'theme-classic.css';
-    document.getElementById('themeStylesheet').href = theme;
-  </script>
   <pre id="log"></pre>
   <div id="readyBox" class="readyBar"></div>
   <input id="chatInput" placeholder="message" autocomplete="off" />

--- a/public/classinfo.html
+++ b/public/classinfo.html
@@ -4,14 +4,14 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Class Info</title>
-  <link id="themeStylesheet" rel="stylesheet" href="theme-classic.css" />
+  <link rel="stylesheet" href="theme-bw.css" />
   <style>
     body {
       font-family: monospace;
       padding: 1rem;
       margin: 0 auto;
-      max-width: 600px;
-      font-size: 18px;
+      max-width: 100%;
+      font-size: 16px;
       line-height: 1.4;
       background: var(--bg);
       color: var(--fg);
@@ -24,10 +24,6 @@
   </style>
 </head>
 <body>
-  <script>
-    const theme = localStorage.getItem('theme') || 'theme-classic.css';
-    document.getElementById('themeStylesheet').href = theme;
-  </script>
   <pre id="infoDisplay">Loading...</pre>
   <p><a href="player.html">&#x2B05; Back</a></p>
   <script>

--- a/public/dm.html
+++ b/public/dm.html
@@ -4,15 +4,15 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>OSE RPG - GM Tools</title>
-  <link id="themeStylesheet" rel="stylesheet" href="theme-classic.css" />
+  <link rel="stylesheet" href="theme-bw.css" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Tiny5&family=Micro+5+Charted&family=Jacquard+12&family=Jacquarda+Bastarda+9&family=Jacquard+24&display=swap">
   <style>
     body {
       font-family: 'Tiny5', monospace;
       margin: 0 auto;
-      max-width: 600px;
+      max-width: 100%;
       padding: 1rem;
-      font-size: 18px;
+      font-size: 16px;
       line-height: 1.4;
       background: var(--bg);
       color: var(--fg);
@@ -70,10 +70,6 @@
   </style>
 </head>
 <body>
-  <script>
-    const theme = localStorage.getItem('theme') || 'theme-classic.css';
-    document.getElementById('themeStylesheet').href = theme;
-  </script>
   <h1>OSE RPG GM Interface</h1>
   <label>Font:
     <select id="fontPicker">

--- a/public/gm_menu.js
+++ b/public/gm_menu.js
@@ -704,6 +704,18 @@ newMapBtn.addEventListener('click', () => {
   await loadTileset();
   tiles = TILES;
   selectedTile = TILES[0];
-  showMainMenu();
+  if (location.hash === '#region') {
+    generateRegionMap(20);
+    numberedMap = false;
+    buildPalette();
+    mapName = '';
+    mapNameInput.value = '';
+    mapControls.style.display = 'block';
+    drawMap();
+    display.textContent = 'Editing new region map\n0. Return';
+    mode = 'editmap';
+  } else {
+    showMainMenu();
+  }
   input.focus();
 })();

--- a/public/index.html
+++ b/public/index.html
@@ -4,15 +4,15 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>OSE RPG Entry</title>
-  <link id="themeStylesheet" rel="stylesheet" href="theme-classic.css" />
+  <link rel="stylesheet" href="theme-bw.css" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Tiny5&family=Jacquard+12&display=swap">
   <style>
       body {
         font-family: 'Tiny5', monospace;
-      padding: 2rem;
-      max-width: 600px;
+      padding: 1rem;
+      max-width: 100%;
       margin: 0 auto;
-      font-size: 18px;
+      font-size: 16px;
       line-height: 1.4;
       background: var(--bg);
       color: var(--fg);
@@ -24,19 +24,6 @@
   <h1 style="font-family:'Jacquard 12',serif;">The Blocland Lands</h1>
   <p><a href="/player.html">▶ Join as Player</a></p>
   <p><a href="/dm.html">🎲 Launch GM Tools</a></p>
-  <p><a href="#" id="toggleTheme">Toggle Theme</a></p>
-  <script>
-    const themeEl = document.getElementById('themeStylesheet');
-    themeEl.href = 'theme-msdos.css';
-    localStorage.setItem('theme', 'theme-msdos.css');
-    const themes = ['theme-msdos.css', 'theme-classic.css', 'theme-dark.css'];
-    document.getElementById('toggleTheme').onclick = () => {
-      const current = themeEl.getAttribute('href');
-      const idx = themes.indexOf(current);
-      const next = themes[(idx + 1) % themes.length];
-      themeEl.href = next;
-      localStorage.setItem('theme', next);
-    };
-  </script>
+  <p><a href="/dm.html#region">🗺️ Region Map Maker</a></p>
 </body>
 </html>

--- a/public/items.html
+++ b/public/items.html
@@ -4,15 +4,15 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Items</title>
-  <link id="themeStylesheet" rel="stylesheet" href="theme-classic.css" />
+  <link rel="stylesheet" href="theme-bw.css" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Tiny5&family=Jacquard+12&family=Jacquarda+Bastarda+9&family=Jacquard+24&display=swap">
   <style>
     body {
       font-family: 'Tiny5', monospace;
       padding: 1rem;
       margin: 0 auto;
-      max-width: 600px;
-      font-size: 18px;
+      max-width: 100%;
+      font-size: 16px;
       line-height: 1.4;
       background: var(--bg);
       color: var(--fg);
@@ -21,10 +21,6 @@
   </style>
 </head>
 <body>
-  <script>
-    const theme = localStorage.getItem('theme') || 'theme-classic.css';
-    document.getElementById('themeStylesheet').href = theme;
-  </script>
   <div id="itemsDisplay">Loading...</div>
   <p><a href="player.html">&#x2B05; Back</a></p>
 

--- a/public/journal.html
+++ b/public/journal.html
@@ -4,14 +4,14 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Journal</title>
-  <link id="themeStylesheet" rel="stylesheet" href="theme-classic.css" />
+  <link rel="stylesheet" href="theme-bw.css" />
   <style>
     body {
       font-family: monospace;
       padding: 1rem;
       margin: 0 auto;
-      max-width: 600px;
-      font-size: 18px;
+      max-width: 100%;
+      font-size: 16px;
       line-height: 1.4;
       background: var(--bg);
       color: var(--fg);
@@ -30,10 +30,6 @@
   </style>
 </head>
 <body>
-  <script>
-    const theme = localStorage.getItem('theme') || 'theme-classic.css';
-    document.getElementById('themeStylesheet').href = theme;
-  </script>
   <pre id="journal">Loading...</pre>
   <p><a href="player.html">&#x2B05; Back</a></p>
 

--- a/public/lore.html
+++ b/public/lore.html
@@ -4,15 +4,15 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Lore Book</title>
-  <link id="themeStylesheet" rel="stylesheet" href="theme-classic.css" />
+  <link rel="stylesheet" href="theme-bw.css" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Tiny5&family=Jacquard+12&family=Jacquarda+Bastarda+9&family=Jacquard+24&display=swap">
   <style>
     body {
       font-family: 'Tiny5', monospace;
       padding: 1rem;
       margin: 0 auto;
-      max-width: 600px;
-      font-size: 18px;
+      max-width: 100%;
+      font-size: 16px;
       line-height: 1.4;
       background: var(--bg);
       color: var(--fg);
@@ -22,10 +22,6 @@
   </style>
 </head>
 <body>
-  <script>
-    const theme = localStorage.getItem('theme') || 'theme-classic.css';
-    document.getElementById('themeStylesheet').href = theme;
-  </script>
   <div id="content">Loading...</div>
   <p><a href="player.html">&#x2B05; Back</a></p>
   <script src="/socket.io/socket.io.js"></script>

--- a/public/map.html
+++ b/public/map.html
@@ -4,15 +4,15 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Map</title>
-  <link id="themeStylesheet" rel="stylesheet" href="theme-classic.css" />
+  <link rel="stylesheet" href="theme-bw.css" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Tiny5&family=Micro+5+Charted&display=swap">
   <style>
     body {
       font-family: 'Tiny5', monospace;
       padding: 1rem;
       margin: 0 auto;
-      max-width: 600px;
-      font-size: 18px;
+      max-width: 100%;
+      font-size: 16px;
       line-height: 1.4;
       background: var(--bg);
       color: var(--fg);
@@ -22,10 +22,6 @@
   </style>
 </head>
 <body>
-  <script>
-    const theme = localStorage.getItem('theme') || 'theme-classic.css';
-    document.getElementById('themeStylesheet').href = theme;
-  </script>
   <canvas id="mapCanvas" width="600" height="600"></canvas>
   <pre id="legend"></pre>
   <p><a href="player.html">&#x2B05; Back</a></p>

--- a/public/player.html
+++ b/public/player.html
@@ -4,15 +4,15 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>OSE RPG - Player</title>
-  <link id="themeStylesheet" rel="stylesheet" href="theme-classic.css" />
+  <link rel="stylesheet" href="theme-bw.css" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Tiny5&family=Micro+5+Charted&family=Jacquard+12&family=Jacquarda+Bastarda+9&family=Jacquard+24&display=swap">
   <style>
     body {
       font-family: 'Tiny5', monospace;
       margin: 0 auto;
       padding: 1rem;
-      max-width: 600px;
-      font-size: 18px;
+      max-width: 100%;
+      font-size: 16px;
       line-height: 1.4;
       background: var(--bg);
       color: var(--fg);
@@ -30,19 +30,16 @@
     }
     #commandInput {
       width: 100%;
-      font-size: 18px;
+      font-size: 16px;
       padding: 0.5rem;
       border: 1px solid var(--border);
       background: var(--accent-bg);
       color: var(--accent-fg);
+      font-family: 'Tiny5', monospace;
     }
   </style>
 </head>
 <body>
-  <script>
-    const theme = localStorage.getItem('theme') || 'theme-classic.css';
-    document.getElementById('themeStylesheet').href = theme;
-  </script>
   <div id="gameDisplay">Welcome, adventurer!
 Enter your name:</div>
   <input id="commandInput" placeholder=">" autocomplete="off" autofocus>

--- a/public/spells.html
+++ b/public/spells.html
@@ -4,15 +4,15 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Spells</title>
-  <link id="themeStylesheet" rel="stylesheet" href="theme-classic.css" />
+  <link rel="stylesheet" href="theme-bw.css" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Tiny5&family=Jacquard+12&family=Jacquarda+Bastarda+9&family=Jacquard+24&display=swap">
   <style>
     body {
       font-family: 'Tiny5', monospace;
       padding: 1rem;
       margin: 0 auto;
-      max-width: 600px;
-      font-size: 18px;
+      max-width: 100%;
+      font-size: 16px;
       line-height: 1.4;
       background: var(--bg);
       color: var(--fg);
@@ -22,10 +22,6 @@
   </style>
 </head>
 <body>
-  <script>
-    const theme = localStorage.getItem('theme') || 'theme-classic.css';
-    document.getElementById('themeStylesheet').href = theme;
-  </script>
   <pre id="spellDisplay">Loading...</pre>
   <p><a href="player.html">&#x2B05; Back</a></p>
 


### PR DESCRIPTION
## Summary
- default to black & white look
- remove theme selector and localStorage theming
- shrink fonts and optimize layout for mobile
- add Region Map Maker link
- allow direct access to region map editing via `dm.html#region`

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685ca0f426c083329206c44501b3d04f