### PR TITLE
Apply dark theme and update chat prompts

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>OSE RPG Entry</title>
-  <link rel="stylesheet" href="public/theme-bw.css" />
+  <link rel="stylesheet" href="public/theme-dark.css" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Tiny5&family=Micro+5+Charted&family=Jacquard+12&display=swap">
   <style>
     body { font-family: 'Tiny5', monospace; padding: 1rem; max-width: 100%; margin: 0 auto; font-size: 16px; line-height: 1.4; background: var(--bg); color: var(--fg); }
@@ -15,6 +15,5 @@
   <h1 style="font-family:'Jacquard 12',serif;">The Blocland Lands</h1>
   <p><a href="/player.html">▶ Join as Player</a></p>
   <p><a href="/dm.html">🎲 Launch GM Tools</a></p>
-  <p><a href="/dm.html#region">🗺️ Region Map Maker</a></p>
 </body>
 </html>

--- a/public/character.html
+++ b/public/character.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Character Sheet</title>
-  <link rel="stylesheet" href="theme-bw.css" />
+  <link rel="stylesheet" href="theme-dark.css" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Tiny5&family=Jacquard+12&family=Jacquarda+Bastarda+9&family=Jacquard+24&display=swap">
   <style>
     body {

--- a/public/chat.html
+++ b/public/chat.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Chat</title>
-  <link rel="stylesheet" href="theme-bw.css" />
+  <link rel="stylesheet" href="theme-dark.css" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Tiny5&family=Jacquard+12&family=Jacquarda+Bastarda+9&family=Jacquard+24&display=swap">
   <style>
     body {
@@ -18,7 +18,14 @@
       color: var(--fg);
     }
     a { color: var(--link); }
-    pre { height: 60vh; overflow-y: auto; white-space: pre-wrap; border: 1px solid var(--border); padding: 0.5rem; }
+    pre {
+      height: 60vh;
+      overflow-y: auto;
+      white-space: pre-wrap;
+      border: 1px solid var(--border);
+      padding: 0.5rem;
+      font-family: 'Tiny5', monospace;
+    }
     .readyBar { border: 1px solid var(--border); padding: 0.25rem; margin-top: 0.5rem; display: flex; flex-wrap: wrap; gap: 0.25rem; }
     .readyBar span { white-space: nowrap; }
     .char { color: deepskyblue; }

--- a/public/classinfo.html
+++ b/public/classinfo.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Class Info</title>
-  <link rel="stylesheet" href="theme-bw.css" />
+  <link rel="stylesheet" href="theme-dark.css" />
   <style>
     body {
       font-family: monospace;

--- a/public/dm.html
+++ b/public/dm.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>OSE RPG - GM Tools</title>
-  <link rel="stylesheet" href="theme-bw.css" />
+  <link rel="stylesheet" href="theme-dark.css" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Tiny5&family=Micro+5+Charted&family=Jacquard+12&family=Jacquarda+Bastarda+9&family=Jacquard+24&display=swap">
   <style>
     body {

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>OSE RPG Entry</title>
-  <link rel="stylesheet" href="theme-bw.css" />
+  <link rel="stylesheet" href="theme-dark.css" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Tiny5&family=Jacquard+12&display=swap">
   <style>
       body {
@@ -24,6 +24,5 @@
   <h1 style="font-family:'Jacquard 12',serif;">The Blocland Lands</h1>
   <p><a href="/player.html">▶ Join as Player</a></p>
   <p><a href="/dm.html">🎲 Launch GM Tools</a></p>
-  <p><a href="/dm.html#region">🗺️ Region Map Maker</a></p>
 </body>
 </html>

--- a/public/items.html
+++ b/public/items.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Items</title>
-  <link rel="stylesheet" href="theme-bw.css" />
+  <link rel="stylesheet" href="theme-dark.css" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Tiny5&family=Jacquard+12&family=Jacquarda+Bastarda+9&family=Jacquard+24&display=swap">
   <style>
     body {

--- a/public/journal.html
+++ b/public/journal.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Journal</title>
-  <link rel="stylesheet" href="theme-bw.css" />
+  <link rel="stylesheet" href="theme-dark.css" />
   <style>
     body {
       font-family: monospace;

--- a/public/lore.html
+++ b/public/lore.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Lore Book</title>
-  <link rel="stylesheet" href="theme-bw.css" />
+  <link rel="stylesheet" href="theme-dark.css" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Tiny5&family=Jacquard+12&family=Jacquarda+Bastarda+9&family=Jacquard+24&display=swap">
   <style>
     body {

--- a/public/map.html
+++ b/public/map.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Map</title>
-  <link rel="stylesheet" href="theme-bw.css" />
+  <link rel="stylesheet" href="theme-dark.css" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Tiny5&family=Micro+5+Charted&display=swap">
   <style>
     body {

--- a/public/player.html
+++ b/public/player.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>OSE RPG - Player</title>
-  <link rel="stylesheet" href="theme-bw.css" />
+  <link rel="stylesheet" href="theme-dark.css" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Tiny5&family=Micro+5+Charted&family=Jacquard+12&family=Jacquarda+Bastarda+9&family=Jacquard+24&display=swap">
   <style>
     body {

--- a/public/player_client.js
+++ b/public/player_client.js
@@ -514,11 +514,11 @@ window.onload = function () {
         const choice = religionChoices[idx];
         if (choice === 'None') {
           currentChar.religion = { type: 'none' };
-          printMessage('Where does your spirituality rest lost one?');
+          printMessage('Where does your faith lie Heretic?');
           phase = 'religionNone';
         } else if (choice === 'Monotheistic') {
           currentChar.religion = { type: 'monotheistic' };
-          printMessage('Where does your faith lie heretic one?');
+          printMessage('Which sect do you belong to Oh Holy One');
           phase = 'religionMono';
         } else {
           currentChar.religion = { type: 'polytheistic' };

--- a/public/spells.html
+++ b/public/spells.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Spells</title>
-  <link rel="stylesheet" href="theme-bw.css" />
+  <link rel="stylesheet" href="theme-dark.css" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Tiny5&family=Jacquard+12&family=Jacquarda+Bastarda+9&family=Jacquard+24&display=swap">
   <style>
     body {


### PR DESCRIPTION
## Summary
- switch all pages to dark mode theme
- remove Region Map Maker link from the index page
- change monotheistic and none religion prompts
- make chat log use Tiny5 font

## Testing
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685ca505acfc8332beafed2c813cf913