### PR TITLE
Add generator menu scaffolding and fix region maps

### DIFF
--- a/public/knave_tables.json
+++ b/public/knave_tables.json
@@ -1,0 +1,18 @@
+{
+  "Background": [
+    "Alchemist",
+    "Beggar",
+    "Hunter",
+    "Mercenary",
+    "Sailor",
+    "Scholar"
+  ],
+  "Physical Detail": [
+    "Scarred",
+    "Tall",
+    "One-eyed",
+    "Tattooed",
+    "Lame",
+    "Bearded"
+  ]
+}


### PR DESCRIPTION
## Summary
- fix DM region maps so they start visible
- add generator menu with placeholder tables
- load generator tables from new `knave_tables.json`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ca76ce3288332922bca040c64b305