### PR TITLE
Fix new map focus issue

### DIFF
--- a/public/gm_menu.js
+++ b/public/gm_menu.js
@@ -770,6 +770,7 @@ saveMapBtn.addEventListener('click', () => {
 newMapBtn.addEventListener('click', () => {
   display.textContent = 'Map Type\n1. World\n2. Region\n3. Dungeon\n0. Cancel';
   mode = 'newMapType';
+  input.focus();
 });
 
 (async () => {


### PR DESCRIPTION
## Summary
- keep keyboard input focused after clicking **New Map**

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d9fe78a74833293686facd3cf9c77