### PR TITLE
Implement MS-DOS style square map maker

### DIFF
--- a/public/dm.html
+++ b/public/dm.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>OSE RPG - GM Tools</title>
-  <link rel="stylesheet" href="theme-dark.css" />
+  <link rel="stylesheet" href="theme-msdos.css" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Tiny5&family=Micro+5+Charted&family=Jacquard+12&family=Jacquarda+Bastarda+9&family=Jacquard+24&display=swap">
   <style>
     body {
@@ -38,6 +38,11 @@
       cursor: pointer;
       width: 30px;
       height: 30px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--fg);
+      font-family: 'Tiny5', monospace;
     }
     #colorPalette {
       position: fixed;

--- a/public/gm_menu.js
+++ b/public/gm_menu.js
@@ -25,6 +25,7 @@ let numberedMap = false;
 let charNameTemp = '';
 
 let tiles = [];
+const TEXT_TILES = ['V','R','F','L','M','C','T','K','S','-','~','+'];
 const colorPalette = ['#592B18','#8A5A2B','#4A3C2B','#2E4A3C','#403A6C','#6C2E47','#5B2814','#888888'];
 
 let generatorTables = {};
@@ -120,20 +121,21 @@ function buildColorPalette() {
 function buildPalette() {
   palette.innerHTML = '';
   tiles.forEach((t) => {
-    const c = document.createElement('canvas');
-    c.width = c.height = cellSize;
-    c.className = 'tileBtn';
-    const cctx = c.getContext('2d');
-    drawTile(cctx, t);
-    if (t === selectedTile) c.classList.add('tileSel');
-    c.onclick = () => {
+    const d = document.createElement('div');
+    d.className = 'tileBtn';
+    d.style.display = 'flex';
+    d.style.alignItems = 'center';
+    d.style.justifyContent = 'center';
+    d.textContent = t;
+    if (t === selectedTile) d.classList.add('tileSel');
+    d.onclick = () => {
       selectedTile = t;
       document
         .querySelectorAll('.tileBtn')
         .forEach((b) => b.classList.remove('tileSel'));
-      c.classList.add('tileSel');
+      d.classList.add('tileSel');
     };
-    palette.appendChild(c);
+    palette.appendChild(d);
   });
 }
 
@@ -254,7 +256,7 @@ function drawMap() {
       const cell = mapData[y][x];
       if (typeof cell === 'string' && cell && !cell.startsWith('#') && !tileImages[cell]) {
         if (/^[-~+][hv]$/.test(cell)) {
-          ctx.fillStyle = '#222';
+          ctx.fillStyle = '#000';
           ctx.fillRect(x * cellSize, y * cellSize, cellSize, cellSize);
           ctx.strokeStyle = cell[0] === '+' ? 'red' : cell[0] === '~' ? '#666' : '#fff';
           ctx.lineWidth = 2;
@@ -268,7 +270,7 @@ function drawMap() {
           }
           ctx.stroke();
         } else {
-          ctx.fillStyle = '#222';
+          ctx.fillStyle = '#000';
           ctx.fillRect(x * cellSize, y * cellSize, cellSize, cellSize);
           ctx.fillStyle = '#fff';
           ctx.font = '14px "Tiny5", monospace';
@@ -293,7 +295,7 @@ function drawMap() {
       }
     }
   }
-  ctx.strokeStyle = '#555';
+  ctx.strokeStyle = '#fff';
   for (let x = 0; x <= mapData[0].length; x++) {
     ctx.beginPath();
     ctx.moveTo(x * cellSize + 0.5, 0);
@@ -792,10 +794,9 @@ newMapBtn.addEventListener('click', () => {
 });
 
 (async () => {
-  await loadTileset();
   await loadTables();
-  tiles = TILES;
-  selectedTile = TILES[0];
+  tiles = TEXT_TILES;
+  selectedTile = TEXT_TILES[0];
   if (location.hash === '#region') {
     generateRegionMap(20);
     numberedMap = false;
@@ -805,6 +806,24 @@ newMapBtn.addEventListener('click', () => {
     mapControls.style.display = 'block';
     drawMap();
     display.textContent = 'Editing new region map\n0. Return';
+    mode = 'editmap';
+  } else if (location.hash === '#world') {
+    createWorldMap();
+    buildColorPalette();
+    mapName = '';
+    mapNameInput.value = '';
+    mapControls.style.display = 'block';
+    drawMap();
+    display.textContent = 'Editing new world map\n0. Return';
+    mode = 'editmap';
+  } else if (location.hash === '#dungeon') {
+    createDungeonMap();
+    buildColorPalette();
+    mapName = '';
+    mapNameInput.value = '';
+    mapControls.style.display = 'block';
+    drawMap();
+    display.textContent = 'Editing new dungeon map\n0. Return';
     mode = 'editmap';
   } else {
     showMainMenu();

--- a/public/index.html
+++ b/public/index.html
@@ -24,6 +24,8 @@
   <h1 style="font-family:'Jacquard 12',serif;">The Blocland Lands</h1>
   <p><a href="/player.html">▶ Join as Player</a></p>
   <p><a href="/dm.html">🎲 Launch GM Tools</a></p>
+  <p><a href="/dm.html#world">🗺️ World Map Maker</a></p>
   <p><a href="/dm.html#region">🗺️ Region Map Maker</a></p>
+  <p><a href="/dm.html#dungeon">🗺️ Dungeon Map Maker</a></p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace DM page theme with ms-dos look
- switch map maker to text icons and square grid
- show numbered world/dungeon maps using color picker
- auto open map makers with URL hashes `#world`, `#region` and `#dungeon`
- update index links for the different map makers

## Testing
- `node --check server.js`
- `node --check public/gm_menu.js`

------
https://chatgpt.com/codex/tasks/task_e_685da4686098833297e8597f2d4b9f8f