### PR TITLE
Update map tools and add setting seed generator

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,5 @@
   <h1 style="font-family:'Jacquard 12',serif;">The Blocland Lands</h1>
   <p><a href="/player.html">▶ Join as Player</a></p>
   <p><a href="/dm.html">🎲 Launch GM Tools</a></p>
-  <p><a href="/dm.html#region">🗺️ Region Map Maker</a></p>
 </body>
 </html>

--- a/public/dm.html
+++ b/public/dm.html
@@ -2,7 +2,6 @@
 <html>
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>OSE RPG - GM Tools</title>
   <link rel="stylesheet" href="theme-msdos.css" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Tiny5&family=Micro+5+Charted&family=Jacquard+12&family=Jacquarda+Bastarda+9&family=Jacquard+24&display=swap">
@@ -46,7 +45,7 @@
     }
     #colorPalette {
       position: fixed;
-      left: 0.5rem;
+      right: 0.5rem;
       top: 0.5rem;
       bottom: 0.5rem;
       width: 100px;

--- a/public/gm_menu.js
+++ b/public/gm_menu.js
@@ -28,6 +28,19 @@ let tiles = [];
 const TEXT_TILES = ['V','R','F','L','M','C','T','K','S','-','~','+'];
 const colorPalette = ['#592B18','#8A5A2B','#4A3C2B','#2E4A3C','#403A6C','#6C2E47','#5B2814','#888888'];
 
+const SETTING_SEEDS = [
+  'Remote valley ruled by jealous spirits',
+  'Quiet coast stalked by cunning raiders',
+  'Wind‑swept moor hiding ancient cairns',
+  'Flooded forest teeming with witch covens',
+  'Mountain pass patrolled by rival clans',
+  'Dusty plateau scattered with bizarre relics',
+  'Island refuge corrupted by a fallen order',
+  'Frozen wastes haunted by restless dead',
+  'Sombre wood contested by fey courts',
+  'Borderlands wracked by endless storms'
+];
+
 let generatorTables = {};
 
 async function loadTables() {
@@ -88,6 +101,10 @@ function createDungeonMap() {
   mapNotes = Array.from({ length: size }, () => Array(size).fill(''));
 }
 
+function randomSettingSeed() {
+  return SETTING_SEEDS[Math.floor(Math.random() * SETTING_SEEDS.length)];
+}
+
 function startEditingMap() {
   mapName = '';
   mapNameInput.value = '';
@@ -95,7 +112,9 @@ function startEditingMap() {
   else buildPalette();
   mapControls.style.display = 'block';
   drawMap();
-  display.textContent = 'Editing new map\n0. Return';
+  display.textContent = numberedMap
+    ? 'Editing new map\n0. Return'
+    : 'Editing new map\nS. Generate Seed\n0. Return';
   mode = 'editmap';
 }
 
@@ -458,7 +477,9 @@ function handleInput(text) {
   } else if (mode === 'log') {
     if (text === '0') showMainMenu();
   } else if (mode === 'editmap') {
-    if (text === '0') {
+    if (!numberedMap && text.toLowerCase() === 's') {
+      display.textContent += '\n' + randomSettingSeed();
+    } else if (text === '0') {
       showMainMenu();
       palette.style.display = 'none';
       colorPaletteEl.style.display = 'none';
@@ -805,7 +826,7 @@ newMapBtn.addEventListener('click', () => {
     mapNameInput.value = '';
     mapControls.style.display = 'block';
     drawMap();
-    display.textContent = 'Editing new region map\n0. Return';
+    display.textContent = 'Editing new region map\nS. Generate Seed\n0. Return';
     mode = 'editmap';
   } else if (location.hash === '#world') {
     createWorldMap();

--- a/public/map.html
+++ b/public/map.html
@@ -2,7 +2,6 @@
 <html>
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Map</title>
   <link rel="stylesheet" href="theme-dark.css" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Tiny5&family=Micro+5+Charted&display=swap">


### PR DESCRIPTION
## Summary
- remove region map maker link from index
- shift map color palette toolbar to right
- drop mobile formatting from map pages
- add region setting seed generator option

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685da71bda40833295db430346b23680