### PR TITLE
Remove path tiles from maps

### DIFF
--- a/public/dm.html
+++ b/public/dm.html
@@ -60,6 +60,7 @@
       width: 30px;
       height: 30px;
     }
+    #mapInfo { margin-top: 1rem; white-space: pre-wrap; }
     .colorSel { outline: 2px solid red; }
     .tileSel { outline: 2px solid red; }
     .char { color: deepskyblue; }
@@ -91,6 +92,7 @@
   <pre id="readyDisplay"></pre>
   <pre id="logDisplay"></pre>
   <canvas id="hexMap" width="600" height="600" style="display:none"></canvas>
+  <pre id="mapInfo"></pre>
   <div id="tilePalette" style="display:none"></div>
   <div id="colorPalette" style="display:none"></div>
   <div id="mapControls" style="display:none">

--- a/public/gm_menu.js
+++ b/public/gm_menu.js
@@ -10,13 +10,13 @@ const mapNameInput = document.getElementById('mapName');
 const saveMapBtn = document.getElementById('saveMapBtn');
 const newMapBtn = document.getElementById('newMapBtn');
 const readyDisplay = document.getElementById('readyDisplay');
+const infoDisplay = document.getElementById('mapInfo');
 const ctx = canvas.getContext('2d');
 const cellSize = TILE_SIZE;
 let mode = 'main';
 let mapData = [];
 let mapHidden = [];
 let mapNotes = [];
-let lastTrail = null;
 let mapName = '';
 let selectedTile = '';
 let selectedColor = '#000000';
@@ -25,8 +25,20 @@ let numberedMap = false;
 let charNameTemp = '';
 
 let tiles = [];
-const TEXT_TILES = ['V','R','F','L','M','C','T','K','S','-','~','+'];
+const TEXT_TILES = ['V','R','F','L','M','C','T','K','S'];
 const colorPalette = ['#592B18','#8A5A2B','#4A3C2B','#2E4A3C','#403A6C','#6C2E47','#5B2814','#888888'];
+
+const LEGEND = {
+  V: 'Village',
+  R: 'Ruins',
+  F: 'Forest',
+  L: 'Lake',
+  M: 'Mount/Mine',
+  C: 'Caves',
+  T: 'Tower',
+  K: 'Keep',
+  S: 'Shrine'
+};
 
 const SETTING_SEEDS = [
   'Remote valley ruled by jealous spirits',
@@ -53,7 +65,7 @@ async function loadTables() {
 }
 
 function generateRegionMap(size) {
-  mapData = Array.from({ length: size }, () => Array(size).fill(''));
+  mapData = Array.from({ length: size }, () => Array(size).fill('#000'));
   // region maps should be fully visible for the GM when first created
   mapHidden = Array.from({ length: size }, () => Array(size).fill(false));
   mapNotes = Array.from({ length: size }, () => Array(size).fill(''));
@@ -73,7 +85,9 @@ function generateRegionMap(size) {
     const x = Math.floor(Math.random() * size);
     const y = Math.floor(Math.random() * size);
     mapData[y][x] = f[0].toUpperCase();
+    mapNotes[y][x] = f;
   });
+  buildMapInfo();
 }
 
 function createWorldMap() {
@@ -83,6 +97,7 @@ function createWorldMap() {
   mapData = Array.from({ length: size }, () => Array(size).fill(selectedColor));
   mapHidden = Array.from({ length: size }, () => Array(size).fill(true));
   mapNotes = Array.from({ length: size }, () => Array(size).fill(''));
+  buildMapInfo();
 }
 
 function createRegionMap() {
@@ -99,6 +114,7 @@ function createDungeonMap() {
   mapData = Array.from({ length: size }, () => Array(size).fill(selectedColor));
   mapHidden = Array.from({ length: size }, () => Array(size).fill(true));
   mapNotes = Array.from({ length: size }, () => Array(size).fill(''));
+  buildMapInfo();
 }
 
 function randomSettingSeed() {
@@ -266,6 +282,34 @@ function showTableMenu(title) {
   mode = 'genTable';
 }
 
+function noteNumber(x, y) {
+  let n = 0;
+  for (let yy = 0; yy < mapNotes.length; yy++) {
+    for (let xx = 0; xx < mapNotes[yy].length; xx++) {
+      if (mapNotes[yy][xx]) {
+        n++;
+        if (xx === x && yy === y) return n;
+      }
+    }
+  }
+  return null;
+}
+
+function buildMapInfo() {
+  const lines = [];
+  Object.entries(LEGEND).forEach(([k, v]) => lines.push(`${k}: ${v}`));
+  let n = 0;
+  for (let y = 0; y < mapNotes.length; y++) {
+    for (let x = 0; x < mapNotes[y].length; x++) {
+      if (mapNotes[y][x]) {
+        n++;
+        lines.push(`${n}. ${mapNotes[y][x]}`);
+      }
+    }
+  }
+  if (infoDisplay) infoDisplay.innerHTML = lines.join('<br>');
+}
+
 function drawMap() {
   canvas.width = mapData[0].length * cellSize;
   canvas.height = mapData.length * cellSize;
@@ -274,27 +318,11 @@ function drawMap() {
     for (let x = 0; x < mapData[y].length; x++) {
       const cell = mapData[y][x];
       if (typeof cell === 'string' && cell && !cell.startsWith('#') && !tileImages[cell]) {
-        if (/^[-~+][hv]$/.test(cell)) {
-          ctx.fillStyle = '#000';
-          ctx.fillRect(x * cellSize, y * cellSize, cellSize, cellSize);
-          ctx.strokeStyle = cell[0] === '+' ? 'red' : cell[0] === '~' ? '#666' : '#fff';
-          ctx.lineWidth = 2;
-          ctx.beginPath();
-          if (cell[1] === 'h') {
-            ctx.moveTo(x * cellSize, y * cellSize + cellSize/2);
-            ctx.lineTo((x+1) * cellSize, y * cellSize + cellSize/2);
-          } else {
-            ctx.moveTo(x * cellSize + cellSize/2, y * cellSize);
-            ctx.lineTo(x * cellSize + cellSize/2, (y+1) * cellSize);
-          }
-          ctx.stroke();
-        } else {
-          ctx.fillStyle = '#000';
-          ctx.fillRect(x * cellSize, y * cellSize, cellSize, cellSize);
-          ctx.fillStyle = '#fff';
-          ctx.font = '14px "Tiny5", monospace';
-          ctx.fillText(cell, x * cellSize + 8, y * cellSize + 22);
-        }
+        ctx.fillStyle = '#000';
+        ctx.fillRect(x * cellSize, y * cellSize, cellSize, cellSize);
+        ctx.fillStyle = '#fff';
+        ctx.font = '14px "Tiny5", monospace';
+        ctx.fillText(cell, x * cellSize + 8, y * cellSize + 22);
       } else {
         drawTile(ctx, cell, x * cellSize, y * cellSize);
       }
@@ -311,6 +339,13 @@ function drawMap() {
         ctx.font = '10px monospace';
         const idx = y * mapData[0].length + x + 1;
         ctx.fillText(idx, x * cellSize + 2, y * cellSize + 10);
+      } else if (mapNotes[y] && mapNotes[y][x]) {
+        const n = noteNumber(x, y);
+        if (n) {
+          ctx.fillStyle = '#0f0';
+          ctx.font = '10px monospace';
+          ctx.fillText(n, x * cellSize + 2, y * cellSize + 10);
+        }
       }
     }
   }
@@ -732,6 +767,7 @@ socket.on('mapData', (data) => {
   mapData = data.cells;
   mapHidden = data.hidden || mapData.map(r => r.map(() => true));
   mapNotes = data.notes || mapData.map(r => r.map(() => ''));
+  buildMapInfo();
   numberedMap = typeof mapData[0][0] === 'string' && mapData[0][0].startsWith('#');
   if (numberedMap) buildColorPalette(); else buildPalette();
   drawMap();
@@ -766,23 +802,13 @@ canvas.addEventListener('click', (ev) => {
       if (note !== null) {
         mapNotes[y][x] = note;
         socket.emit('setMapNote', { x, y, text: note });
+        buildMapInfo();
       }
     } else {
       if (numberedMap) {
         mapData[y][x] = selectedColor;
-        lastTrail = null;
       } else {
-        if (['-','~','+'].includes(selectedTile)) {
-          let orient = 'h';
-          if (lastTrail && Math.abs(lastTrail.x - x) + Math.abs(lastTrail.y - y) === 1) {
-            orient = lastTrail.x !== x ? 'h' : 'v';
-          }
-          mapData[y][x] = selectedTile + orient;
-          lastTrail = {x,y};
-        } else {
-          mapData[y][x] = selectedTile;
-          lastTrail = null;
-        }
+        mapData[y][x] = selectedTile;
       }
       socket.emit('updateMapCell', { x, y, value: mapData[y][x] });
     }
@@ -826,6 +852,7 @@ newMapBtn.addEventListener('click', () => {
     mapNameInput.value = '';
     mapControls.style.display = 'block';
     drawMap();
+    buildMapInfo();
     display.textContent = 'Editing new region map\nS. Generate Seed\n0. Return';
     mode = 'editmap';
   } else if (location.hash === '#world') {
@@ -835,6 +862,7 @@ newMapBtn.addEventListener('click', () => {
     mapNameInput.value = '';
     mapControls.style.display = 'block';
     drawMap();
+    buildMapInfo();
     display.textContent = 'Editing new world map\n0. Return';
     mode = 'editmap';
   } else if (location.hash === '#dungeon') {
@@ -844,6 +872,7 @@ newMapBtn.addEventListener('click', () => {
     mapNameInput.value = '';
     mapControls.style.display = 'block';
     drawMap();
+    buildMapInfo();
     display.textContent = 'Editing new dungeon map\n0. Return';
     mode = 'editmap';
   } else {

--- a/public/map.html
+++ b/public/map.html
@@ -18,11 +18,15 @@
     }
     a { color: var(--link); }
     canvas { border: 1px solid var(--border); background: black; }
+    #mapWrapper { display: flex; }
+    #legend { margin-right: 1rem; }
   </style>
 </head>
 <body>
-  <canvas id="mapCanvas" width="600" height="600"></canvas>
-  <pre id="legend"></pre>
+  <div id="mapWrapper">
+    <pre id="legend"></pre>
+    <canvas id="mapCanvas" width="600" height="600"></canvas>
+  </div>
   <p><a href="player.html">&#x2B05; Back</a></p>
 
   <script src="/socket.io/socket.io.js"></script>
@@ -34,6 +38,7 @@
 
     let mapData = [];
     let mapHidden = [];
+    let mapNotes = [];
     let tokens = {};
     const legendEl = document.getElementById('legend');
     const LEGEND = {
@@ -47,9 +52,34 @@
       K: 'Keep',
       S: 'Shrine'
     };
-    legendEl.textContent = Object.entries(LEGEND)
-      .map(([k, v]) => `${k}: ${v}`)
-      .join('\n');
+      function buildLegend() {
+        const entries = Object.entries(LEGEND).map(([k, v]) => `${k}: ${v}`);
+        let n = 0;
+        for (let y = 0; y < mapNotes.length; y++) {
+          for (let x = 0; x < mapNotes[y].length; x++) {
+            if (mapNotes[y][x]) {
+              n++;
+              entries.push(`${n}. ${mapNotes[y][x]}`);
+            }
+          }
+        }
+        legendEl.innerHTML = entries.join('<br>');
+      }
+    buildLegend();
+
+    function noteNumber(x, y) {
+      let n = 0;
+      for (let yy = 0; yy < mapNotes.length; yy++) {
+        for (let xx = 0; xx < mapNotes[yy].length; xx++) {
+          if (mapNotes[yy][xx]) {
+            n++;
+            if (xx === x && yy === y) return n;
+          }
+        }
+      }
+      return 0;
+    }
+
     const name = localStorage.getItem('characterName') || '';
     let blink = true;
 
@@ -66,7 +96,14 @@
             ctx.fillStyle = 'black';
             ctx.fillRect(x * TILE_SIZE, y * TILE_SIZE, TILE_SIZE, TILE_SIZE);
           } else {
-            drawTile(ctx, mapData[y][x], x * TILE_SIZE, y * TILE_SIZE);
+            const cell = mapData[y][x];
+            drawTile(ctx, cell, x * TILE_SIZE, y * TILE_SIZE);
+          }
+          if (mapNotes[y] && mapNotes[y][x]) {
+            const n = noteNumber(x, y);
+            ctx.fillStyle = '#0f0';
+            ctx.font = '10px monospace';
+            ctx.fillText(n, x * TILE_SIZE + 2, y * TILE_SIZE + 10);
           }
         }
       }
@@ -104,6 +141,8 @@
       socket.on('mapData', (data) => {
         mapData = data.cells;
         mapHidden = data.hidden || mapData.map(r => r.map(() => true));
+        mapNotes = data.notes || mapData.map(r => r.map(() => ''));
+        buildLegend();
         render();
       });
       socket.on('playerPositions', (data) => {


### PR DESCRIPTION
## Summary
- drop path symbols from the GM tile palette
- don't include path information in GM/player map legends
- draw map cells only as terrain tiles

## Testing
- `npm -s run start >/tmp/server.log && tail -n 20 /tmp/server.log` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685da9036454833285ac1023c9f1afd5