### PR TITLE
Replace map menu with dungeon generator

### DIFF
--- a/public/dm.html
+++ b/public/dm.html
@@ -85,7 +85,7 @@
     </select>
   </label>
   <p><a href="index.html">&#x2B05; Back</a></p>
-  <p><a href="dm.html#region">🗺️ Region Map Maker</a></p>
+  <p><a href="dm.html#dungeon">🗺️ Dungeon Map Maker</a></p>
   <pre id="menuDisplay"></pre>
   <input id="gmInput" autocomplete="off" />
   <pre id="readyDisplay"></pre>

--- a/public/index.html
+++ b/public/index.html
@@ -24,8 +24,6 @@
   <h1 style="font-family:'Jacquard 12',serif;">The Blocland Lands</h1>
   <p><a href="/player.html">▶ Join as Player</a></p>
   <p><a href="/dm.html">🎲 Launch GM Tools</a></p>
-  <p><a href="/dm.html#world">🗺️ World Map Maker</a></p>
-  <p><a href="/dm.html#region">🗺️ Region Map Maker</a></p>
   <p><a href="/dm.html#dungeon">🗺️ Dungeon Map Maker</a></p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- rework GM map menu to only create dungeons
- add simple ASCII dungeon generation
- update gm tools and index links

## Testing
- `node --check public/gm_menu.js`

------
https://chatgpt.com/codex/tasks/task_e_685fd73082dc8332b7552eba41044fb7