### PR TITLE
Update README for Dungeon Map Maker

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ setting the `OSE_RPG_DATA_DIR` environment variable.
 
 **GM Map Maker**
 - Choose **Map Menu** from the GM interface.
-- Select **New map** for a blank map or **Map list** to load one to edit.
+- For direct access visit [dm.html#dungeon](dm.html#dungeon) for the Dungeon Map Maker.
+- Select **New Dungeon** for a blank dungeon map or **Map list** to load one to edit.
 - Use the map controls to name and **Save Map**.
 - Choose **Share map** to show a saved map to the players.
 - Tiles are loaded from the built in tileset and shown in a scrollable grid.


### PR DESCRIPTION
## Summary
- mention the dedicated Dungeon Map Maker link
- note that the "New Dungeon" option creates a blank dungeon map

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685fe6c22c18833291a05c66ec0d6e0c