### PR TITLE
Replace map menu with dungeon generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ setting the `OSE_RPG_DATA_DIR` environment variable.
   Click a tile and then a grid cell to place it on the map.
 - The `organized_tiles` directory with tile images must exist in the project
   root. Both `server.js` and `public/tiles.js` load tiles from this folder.
-  Without these assets the map editor, including Region maps, will display
-  blank tiles.
+  Without these assets the map editor will display blank tiles.
 
 **Lore Book**
 - Players can open the lore book from the main menu to view campaign lore.

--- a/public/chat.html
+++ b/public/chat.html
@@ -28,15 +28,15 @@
     }
     .readyBar { border: 1px solid var(--border); padding: 0.25rem; margin-top: 0.5rem; display: flex; flex-wrap: wrap; gap: 0.25rem; }
     .readyBar span { white-space: nowrap; }
-    .char { color: deepskyblue; }
-    .location { color: violet; }
-    .item { color: gold; }
-    .spell { color: orchid; }
-    .monster { color: tomato; }
-    .gold { color: khaki; }
-    .gmchar { color: lightgreen; }
-    .gmevent { color: orange; }
-    .gmstory { color: plum; }
+    .char { color: var(--fg); }
+    .location { color: var(--fg); }
+    .item { color: var(--fg); }
+    .spell { color: var(--fg); }
+    .monster { color: var(--fg); }
+    .gold { color: var(--fg); }
+    .gmchar { color: var(--fg); }
+    .gmevent { color: var(--fg); }
+    .gmstory { color: var(--fg); }
     input { width: 100%; font-size: 16px; margin-top: 0.5rem; background: var(--accent-bg); color: var(--accent-fg); border: 1px solid var(--border); font-family: 'Tiny5', monospace; }
   </style>
 </head>

--- a/public/dm.html
+++ b/public/dm.html
@@ -43,34 +43,16 @@
       color: var(--fg);
       font-family: 'Tiny5', monospace;
     }
-    #colorPalette {
-      position: fixed;
-      right: 0.5rem;
-      top: 0.5rem;
-      bottom: 0.5rem;
-      width: 100px;
-      display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(30px, 1fr));
-      grid-auto-rows: 30px;
-      gap: 2px;
-    }
-    .colorBtn {
-      border: 1px solid var(--border);
-      cursor: pointer;
-      width: 30px;
-      height: 30px;
-    }
-    .colorSel { outline: 2px solid red; }
-    .tileSel { outline: 2px solid red; }
-    .char { color: deepskyblue; }
-    .location { color: violet; }
-    .item { color: gold; }
-    .spell { color: orchid; }
-    .monster { color: tomato; }
-    .gold { color: khaki; }
-    .gmchar { color: lightgreen; }
-    .gmevent { color: orange; }
-    .gmstory { color: plum; }
+    .tileSel { outline: 2px solid var(--fg); }
+    .char { color: var(--fg); }
+    .location { color: var(--fg); }
+    .item { color: var(--fg); }
+    .spell { color: var(--fg); }
+    .monster { color: var(--fg); }
+    .gold { color: var(--fg); }
+    .gmchar { color: var(--fg); }
+    .gmevent { color: var(--fg); }
+    .gmstory { color: var(--fg); }
   </style>
 </head>
 <body>
@@ -85,14 +67,13 @@
     </select>
   </label>
   <p><a href="index.html">&#x2B05; Back</a></p>
-  <p><a href="dm.html#region">🗺️ Region Map Maker</a></p>
+  <p><a href="dm.html#dungeon">🗺️ Dungeon Map Maker</a></p>
   <pre id="menuDisplay"></pre>
   <input id="gmInput" autocomplete="off" />
   <pre id="readyDisplay"></pre>
   <pre id="logDisplay"></pre>
   <canvas id="hexMap" width="600" height="600" style="display:none"></canvas>
   <div id="tilePalette" style="display:none"></div>
-  <div id="colorPalette" style="display:none"></div>
   <div id="mapControls" style="display:none">
     Map Name: <input id="mapName" />
     <button id="saveMapBtn">Save Map</button>

--- a/public/index.html
+++ b/public/index.html
@@ -24,8 +24,6 @@
   <h1 style="font-family:'Jacquard 12',serif;">The Blocland Lands</h1>
   <p><a href="/player.html">▶ Join as Player</a></p>
   <p><a href="/dm.html">🎲 Launch GM Tools</a></p>
-  <p><a href="/dm.html#world">🗺️ World Map Maker</a></p>
-  <p><a href="/dm.html#region">🗺️ Region Map Maker</a></p>
   <p><a href="/dm.html#dungeon">🗺️ Dungeon Map Maker</a></p>
 </body>
 </html>

--- a/public/journal.html
+++ b/public/journal.html
@@ -18,15 +18,15 @@
     }
     a { color: var(--link); }
     pre { white-space: pre-wrap; }
-    .char { color: deepskyblue; }
-    .location { color: violet; }
-    .item { color: gold; }
-    .spell { color: orchid; }
-    .monster { color: tomato; }
-    .gold { color: khaki; }
-    .gmchar { color: lightgreen; }
-    .gmevent { color: orange; }
-    .gmstory { color: plum; }
+    .char { color: var(--fg); }
+    .location { color: var(--fg); }
+    .item { color: var(--fg); }
+    .spell { color: var(--fg); }
+    .monster { color: var(--fg); }
+    .gold { color: var(--fg); }
+    .gmchar { color: var(--fg); }
+    .gmevent { color: var(--fg); }
+    .gmstory { color: var(--fg); }
   </style>
 </head>
 <body>

--- a/public/theme-dark.css
+++ b/public/theme-dark.css
@@ -1,7 +1,7 @@
 :root {
   --bg: #000;
   --fg: #fff;
-  --link: #aaa;
+  --link: #fff;
   --border: #fff;
   --accent-bg: #000;
   --accent-fg: #fff;

--- a/public/theme-msdos.css
+++ b/public/theme-msdos.css
@@ -1,10 +1,10 @@
 :root {
   --bg: #000;
-  --fg: #0f0;
-  --link: #0f0;
-  --border: #0f0;
+  --fg: #fff;
+  --link: #fff;
+  --border: #fff;
   --accent-bg: #000;
-  --accent-fg: #0f0;
+  --accent-fg: #fff;
 }
 
 body {


### PR DESCRIPTION
## Summary
- rework GM map menu to only create dungeons
- add simple ASCII dungeon generation
- update gm tools and index links
- remove world/region map code
- switch all interfaces to a black and white palette

## Testing
- `node --check public/gm_menu.js`


------
https://chatgpt.com/codex/tasks/task_e_685fd73082dc8332b7552eba41044fb7