### PR TITLE
Add basic caravan map

### DIFF
--- a/public/caravan.html
+++ b/public/caravan.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>Caravan Map</title>
+  <link rel="stylesheet" href="theme-dark.css" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Tiny5&display=swap">
+  <style>
+    body { font-family: 'Tiny5', monospace; padding: 1rem; margin: 0 auto; max-width: 100%; background: var(--bg); color: var(--fg); }
+    a { color: var(--link); }
+    canvas { border: 1px solid var(--border); background: black; display:block; margin-top:1rem; }
+  </style>
+</head>
+<body>
+  <h2>Caravan Travel</h2>
+  <canvas id="hexCanvas" width="600" height="400"></canvas>
+  <p><a id="backLink" href="player.html">&#x2B05; Back</a></p>
+  <script src="hexgrid.js"></script>
+  <script>
+    const params = new URLSearchParams(location.search);
+    if (params.get('gm') === '1') {
+      document.getElementById('backLink').href = 'dm.html';
+    }
+  </script>
+</body>
+</html>

--- a/public/gm_menu.js
+++ b/public/gm_menu.js
@@ -197,7 +197,8 @@ function showMainMenu() {
     '8. Help\n' +
     '9. Add Lore\n' +
     '10. Edit Data\n' +
-    '11. Generators';
+    '11. Generators\n' +
+    '12. Caravan Map';
   canvas.style.display = 'none';
   palette.style.display = 'none';
   colorPaletteEl.style.display = 'none';
@@ -435,6 +436,10 @@ function handleInput(text) {
         break;
       case '11':
         showGeneratorMenu();
+        break;
+      case '12':
+        window.open('caravan.html', '_blank');
+        showMainMenu();
         break;
       default:
         showMainMenu();

--- a/public/hexgrid.js
+++ b/public/hexgrid.js
@@ -1,0 +1,36 @@
+(function() {
+  const canvas = document.getElementById('hexCanvas');
+  if (!canvas) return;
+  const ctx = canvas.getContext('2d');
+  const radius = 20;
+  const hexH = Math.sqrt(3) * radius;
+  const cols = Math.floor(canvas.width / (radius * 1.5));
+  const rows = Math.floor(canvas.height / hexH);
+
+  function hexCorner(cx, cy, i) {
+    const angle = Math.PI / 3 * i;
+    return [cx + radius * Math.cos(angle), cy + radius * Math.sin(angle)];
+  }
+
+  function drawHex(cx, cy) {
+    ctx.beginPath();
+    const [sx, sy] = hexCorner(cx, cy, 0);
+    ctx.moveTo(sx, sy);
+    for (let i = 1; i < 6; i++) {
+      const [x, y] = hexCorner(cx, cy, i);
+      ctx.lineTo(x, y);
+    }
+    ctx.closePath();
+    ctx.stroke();
+  }
+
+  ctx.strokeStyle = '#fff';
+
+  for (let q = 0; q < cols; q++) {
+    for (let r = 0; r < rows; r++) {
+      const cx = radius * 1.5 * q + radius;
+      const cy = hexH * (r + 0.5 * (q % 2)) + radius;
+      drawHex(cx, cy);
+    }
+  }
+})();

--- a/public/player_client.js
+++ b/public/player_client.js
@@ -352,6 +352,7 @@ window.onload = function () {
         '8. Save Character\n' +
         '9. Lore Book\n' +
         '10. Export Character\n' +
+        '11. Caravan Map\n' +
         '(Selecting an option opens a new page)'
     );
     careerButton.style.display = 'none';
@@ -721,6 +722,9 @@ window.onload = function () {
         case '10':
           socket.emit('exportCharacter', currentChar.name);
           printMessage('Character exported.');
+          break;
+        case '11':
+          window.location.href = 'caravan.html';
           break;
         default:
           printMessage('Invalid choice.');


### PR DESCRIPTION
## Summary
- add blank caravan hex grid page with one-bit style
- draw grid via new `hexgrid.js`
- link caravan map from player and GM menus

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861d776ec948332bd9217dd4d5c35b0