### PR TITLE
Add numbered hex grid with simple 1-bit tiles

### DIFF
--- a/public/caravan.html
+++ b/public/caravan.html
@@ -15,6 +15,7 @@
   <h2>Caravan Travel</h2>
   <canvas id="hexCanvas" width="600" height="400"></canvas>
   <p><a id="backLink" href="player.html">&#x2B05; Back</a></p>
+  <script src="hex_tiles.js"></script>
   <script src="hexgrid.js"></script>
   <script>
     const params = new URLSearchParams(location.search);

--- a/public/hex_tiles.js
+++ b/public/hex_tiles.js
@@ -1,0 +1,103 @@
+const HEX_TILES = {
+  tree: [
+    '00011000',
+    '00111100',
+    '01111110',
+    '00111100',
+    '00011000',
+    '00011000',
+    '00011000',
+    '00000000'
+  ],
+  hill: [
+    '00000000',
+    '00000000',
+    '00111100',
+    '01111110',
+    '11111111',
+    '00000000',
+    '00000000',
+    '00000000'
+  ],
+  plains: [
+    '00000000',
+    '00000000',
+    '00000000',
+    '00000000',
+    '00000000',
+    '00000000',
+    '00000000',
+    '00000000'
+  ],
+  river: [
+    '00100000',
+    '00110000',
+    '00110000',
+    '00100000',
+    '00110000',
+    '00110000',
+    '00110000',
+    '00100000'
+  ],
+  pond: [
+    '00000000',
+    '00011000',
+    '00111100',
+    '00111100',
+    '00111100',
+    '00111100',
+    '00011000',
+    '00000000'
+  ],
+  mountain: [
+    '00000000',
+    '00010000',
+    '00111000',
+    '01111100',
+    '11111110',
+    '01111100',
+    '00010000',
+    '00000000'
+  ],
+  desert: [
+    '00000000',
+    '01000100',
+    '00000000',
+    '00100010',
+    '00000000',
+    '01000100',
+    '00000000',
+    '00100010'
+  ]
+};
+
+const HEX_TILE_SIZE = 20;
+const hexTileImages = {};
+
+function loadHexTiles() {
+  if (Object.keys(hexTileImages).length) return hexTileImages;
+  Object.keys(HEX_TILES).forEach(name => {
+    const pattern = HEX_TILES[name];
+    const c = document.createElement('canvas');
+    c.width = HEX_TILE_SIZE;
+    c.height = HEX_TILE_SIZE;
+    const ctx = c.getContext('2d');
+    const scale = HEX_TILE_SIZE / pattern.length;
+    ctx.fillStyle = '#000';
+    ctx.fillRect(0, 0, HEX_TILE_SIZE, HEX_TILE_SIZE);
+    ctx.fillStyle = '#fff';
+    for (let y = 0; y < pattern.length; y++) {
+      for (let x = 0; x < pattern[y].length; x++) {
+        if (pattern[y][x] === '1') {
+          ctx.fillRect(x * scale, y * scale, scale, scale);
+        }
+      }
+    }
+    const img = new Image();
+    img.src = c.toDataURL();
+    hexTileImages[name] = img;
+  });
+  return hexTileImages;
+}
+
+window.loadHexTiles = loadHexTiles;

--- a/public/hexgrid.js
+++ b/public/hexgrid.js
@@ -6,6 +6,7 @@
   const hexH = Math.sqrt(3) * radius;
   const cols = Math.floor(canvas.width / (radius * 1.5));
   const rows = Math.floor(canvas.height / hexH);
+  const tiles = loadHexTiles ? loadHexTiles() : {};
 
   function hexCorner(cx, cy, i) {
     const angle = Math.PI / 3 * i;
@@ -25,12 +26,24 @@
   }
 
   ctx.strokeStyle = '#fff';
+  ctx.font = '10px monospace';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
 
+  const tileNames = Object.keys(tiles);
+  let idx = 1;
   for (let q = 0; q < cols; q++) {
     for (let r = 0; r < rows; r++) {
       const cx = radius * 1.5 * q + radius;
       const cy = hexH * (r + 0.5 * (q % 2)) + radius;
+      const name = tileNames[(idx - 1) % tileNames.length];
+      const img = tiles[name];
+      if (img) {
+        ctx.drawImage(img, cx - radius + 2, cy - radius + 2, radius * 2 - 4, radius * 2 - 4);
+      }
       drawHex(cx, cy);
+      ctx.fillText(idx, cx, cy);
+      idx++;
     }
   }
 })();


### PR DESCRIPTION
## Summary
- add simple monochrome tileset for terrain in `hex_tiles.js`
- draw terrain tiles and hex numbers in `hexgrid.js`
- load the new tileset in `caravan.html`

## Testing
- `npm test` *(fails: Missing script)*
- `node -c public/hex_tiles.js`
- `node -c public/hexgrid.js`


------
https://chatgpt.com/codex/tasks/task_e_6861da0289f483328916006467c67d4c