### PR TITLE
Add hex grid tile editor

### DIFF
--- a/public/caravan.html
+++ b/public/caravan.html
@@ -9,18 +9,24 @@
     body { font-family: 'Tiny5', monospace; padding: 1rem; margin: 0 auto; max-width: 100%; background: var(--bg); color: var(--fg); }
     a { color: var(--link); }
     canvas { border: 1px solid var(--border); background: black; display:block; margin-top:1rem; }
+    #hexToolbar { display:none; flex-wrap: wrap; gap: 4px; margin-top: 0.5rem; }
+    .tileBtn { border: 1px solid var(--border); cursor: pointer; width: 30px; height: 30px; display:flex; align-items: center; justify-content: center; }
+    .tileSel { outline: 2px solid red; }
   </style>
 </head>
 <body>
   <h2>Caravan Travel</h2>
   <canvas id="hexCanvas" width="600" height="400"></canvas>
+  <div id="hexToolbar"></div>
   <p><a id="backLink" href="player.html">&#x2B05; Back</a></p>
-  <script src="hexgrid.js"></script>
+  <script src="hex_tiles.js"></script>
   <script>
     const params = new URLSearchParams(location.search);
-    if (params.get('gm') === '1') {
+    window.gmMode = params.get('gm') === '1';
+    if (gmMode) {
       document.getElementById('backLink').href = 'dm.html';
     }
   </script>
+  <script src="hexgrid.js"></script>
 </body>
 </html>

--- a/public/hex_tiles.js
+++ b/public/hex_tiles.js
@@ -1,0 +1,103 @@
+const HEX_TILES = {
+  tree: [
+    '00011000',
+    '00111100',
+    '01111110',
+    '00111100',
+    '00011000',
+    '00011000',
+    '00011000',
+    '00000000'
+  ],
+  hill: [
+    '00000000',
+    '00000000',
+    '00111100',
+    '01111110',
+    '11111111',
+    '00000000',
+    '00000000',
+    '00000000'
+  ],
+  plains: [
+    '00000000',
+    '00000000',
+    '00000000',
+    '00000000',
+    '00000000',
+    '00000000',
+    '00000000',
+    '00000000'
+  ],
+  river: [
+    '00100000',
+    '00110000',
+    '00110000',
+    '00100000',
+    '00110000',
+    '00110000',
+    '00110000',
+    '00100000'
+  ],
+  pond: [
+    '00000000',
+    '00011000',
+    '00111100',
+    '00111100',
+    '00111100',
+    '00111100',
+    '00011000',
+    '00000000'
+  ],
+  mountain: [
+    '00000000',
+    '00010000',
+    '00111000',
+    '01111100',
+    '11111110',
+    '01111100',
+    '00010000',
+    '00000000'
+  ],
+  desert: [
+    '00000000',
+    '01000100',
+    '00000000',
+    '00100010',
+    '00000000',
+    '01000100',
+    '00000000',
+    '00100010'
+  ]
+};
+
+const HEX_TILE_SIZE = 20;
+const hexTileImages = {};
+
+function loadHexTiles() {
+  if (Object.keys(hexTileImages).length) return hexTileImages;
+  Object.keys(HEX_TILES).forEach(name => {
+    const pattern = HEX_TILES[name];
+    const c = document.createElement('canvas');
+    c.width = HEX_TILE_SIZE;
+    c.height = HEX_TILE_SIZE;
+    const ctx = c.getContext('2d');
+    const scale = HEX_TILE_SIZE / pattern.length;
+    ctx.fillStyle = '#000';
+    ctx.fillRect(0, 0, HEX_TILE_SIZE, HEX_TILE_SIZE);
+    ctx.fillStyle = '#fff';
+    for (let y = 0; y < pattern.length; y++) {
+      for (let x = 0; x < pattern[y].length; x++) {
+        if (pattern[y][x] === '1') {
+          ctx.fillRect(x * scale, y * scale, scale, scale);
+        }
+      }
+    }
+    const img = new Image();
+    img.src = c.toDataURL();
+    hexTileImages[name] = img;
+  });
+  return hexTileImages;
+}
+
+window.loadHexTiles = loadHexTiles;

--- a/public/hexgrid.js
+++ b/public/hexgrid.js
@@ -1,4 +1,4 @@
-(function() {
+(() => {
   const canvas = document.getElementById('hexCanvas');
   if (!canvas) return;
   const ctx = canvas.getContext('2d');
@@ -6,6 +6,22 @@
   const hexH = Math.sqrt(3) * radius;
   const cols = Math.floor(canvas.width / (radius * 1.5));
   const rows = Math.floor(canvas.height / hexH);
+  const tiles = typeof loadHexTiles === 'function' ? loadHexTiles() : {};
+  const toolbar = document.getElementById('hexToolbar');
+  const gm = typeof window.gmMode !== 'undefined' ? window.gmMode : false;
+
+  const tileNames = Object.keys(tiles);
+  const defaultTile = tileNames.includes('plains') ? 'plains' : (tileNames[0] || null);
+  let selectedTile = defaultTile;
+  let map = [];
+
+  const saved = localStorage.getItem('hexMap');
+  if (saved) {
+    try { map = JSON.parse(saved); } catch (e) { map = []; }
+  }
+  if (!map.length) {
+    map = Array.from({ length: rows }, () => Array(cols).fill(defaultTile));
+  }
 
   function hexCorner(cx, cy, i) {
     const angle = Math.PI / 3 * i;
@@ -25,12 +41,65 @@
   }
 
   ctx.strokeStyle = '#fff';
+  ctx.fillStyle = '#fff';
+  ctx.font = '10px monospace';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
 
-  for (let q = 0; q < cols; q++) {
-    for (let r = 0; r < rows; r++) {
-      const cx = radius * 1.5 * q + radius;
-      const cy = hexH * (r + 0.5 * (q % 2)) + radius;
-      drawHex(cx, cy);
+  function saveMap() {
+    localStorage.setItem('hexMap', JSON.stringify(map));
+  }
+
+  function draw() {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    let idx = 1;
+    for (let q = 0; q < cols; q++) {
+      for (let r = 0; r < rows; r++) {
+        const cx = radius * 1.5 * q + radius;
+        const cy = hexH * (r + 0.5 * (q % 2)) + radius;
+        const name = map[r][q];
+        const img = tiles[name];
+        if (img) {
+          ctx.drawImage(img, cx - radius + 2, cy - radius + 2, radius * 2 - 4, radius * 2 - 4);
+        }
+        drawHex(cx, cy);
+        ctx.fillText(idx, cx, cy);
+        idx++;
+      }
     }
   }
+
+  if (gm && toolbar) {
+    toolbar.style.display = 'flex';
+    tileNames.forEach((name) => {
+      const btn = document.createElement('canvas');
+      btn.width = 30;
+      btn.height = 30;
+      btn.className = 'tileBtn';
+      const bctx = btn.getContext('2d');
+      const img = tiles[name];
+      if (img) bctx.drawImage(img, 5, 5, 20, 20);
+      if (name === selectedTile) btn.classList.add('tileSel');
+      btn.onclick = () => {
+        selectedTile = name;
+        toolbar.querySelectorAll('.tileBtn').forEach(b => b.classList.remove('tileSel'));
+        btn.classList.add('tileSel');
+      };
+      toolbar.appendChild(btn);
+    });
+
+    canvas.addEventListener('click', (ev) => {
+      const x = ev.offsetX;
+      const y = ev.offsetY;
+      const q = Math.floor(x / (radius * 1.5));
+      const r = Math.floor((y - (q % 2) * hexH / 2) / hexH);
+      if (q >= 0 && q < cols && r >= 0 && r < rows) {
+        map[r][q] = selectedTile;
+        saveMap();
+        draw();
+      }
+    });
+  }
+
+  draw();
 })();


### PR DESCRIPTION
## Summary
- add numbered hex grid to caravan map
- provide simple 1-bit tiles and a toolbar for editing terrain
- persist map to local storage and draw numbers on the grid
- improve hex grid initialization when editor assets are absent

## Testing
- `npm test` *(fails: Missing script)*
- `node -c public/hex_tiles.js`
- `node -c public/hexgrid.js`


------
https://chatgpt.com/codex/tasks/task_e_6861da0289f483328916006467c67d4c